### PR TITLE
Provide the redirect URL in the login form, and allow custom field names.

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import patterns, url, include
 from django.contrib import admin
 
+from two_factor.views import LoginView
+
 
 admin.autodiscover()
 
@@ -10,6 +12,12 @@ urlpatterns = patterns(
         regex=r'^account/logout/$',
         view='django.contrib.auth.views.logout',
         name='logout',
+    ),
+    url(
+        regex=r'account/custom-login/$',
+        view=LoginView.as_view(),
+        kwargs={'redirect_field_name': 'next_page'},
+        name='custom-login',
     ),
     url(r'', include('two_factor.urls', 'two_factor')),
     url(r'^admin/', include(admin.site.urls)),

--- a/two_factor/templates/two_factor/core/login.html
+++ b/two_factor/templates/two_factor/core/login.html
@@ -12,7 +12,6 @@
 
   <form action="" method="post">{% csrf_token %}
     {% include "two_factor/_wizard_forms.html" %}
-    <input type="hidden" name="next" value="{{ next }}" />
 
     {# hidden submit button to enable [enter] key #}
     <div style="margin-left: -500px"><input type="submit" value=""/></div>


### PR DESCRIPTION
This provides the redirect URL provided in the query string (generally
"next", as per `REDIRECT_FIELD_NAME`) to the login form, allowing a page
to invoke a login followed by a redirect to the given page. This mirrors
the functionality of the default login view.

It also brings over the login view's `redirect_field_name` parameter,
allowing a site to customize what query parameter to use. This helps
when transitioning older codebases to the new view.

The template by default uses "next", but this can be overridden in
custom templates.
