### PR TITLE
Allowing redirect urls to be customized by subclasses

### DIFF
--- a/two_factor/views/profile.py
+++ b/two_factor/views/profile.py
@@ -43,14 +43,15 @@ class DisableView(FormView):
     View for disabling two-factor for a user's account.
     """
     template_name = 'two_factor/profile/disable.html'
+    redirect_url = None
     form_class = DisableForm
 
     def get(self, request, *args, **kwargs):
         if not user_has_device(self.request.user):
-            return redirect(str(settings.LOGIN_REDIRECT_URL))
+            return redirect(self.redirect_url or str(settings.LOGIN_REDIRECT_URL))
         return super(DisableView, self).get(request, *args, **kwargs)
 
     def form_valid(self, form):
         for device in devices_for_user(self.request.user):
             device.delete()
-        return redirect(str(settings.LOGIN_REDIRECT_URL))
+        return redirect(self.redirect_url or str(settings.LOGIN_REDIRECT_URL))


### PR DESCRIPTION
I feel the redirect_path parameter I've introduced is a bad name, but it
does achieve the purpose of making it possible to override where we
redirect to for these views.
