### PR TITLE
Set an error code for phone_number_validator.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from mock import patch, Mock, ANY, call
 
+from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
@@ -22,9 +23,10 @@ from django_otp.oath import totp
 from django_otp.util import random_hex
 
 from two_factor.admin import patch_admin, unpatch_admin
+from two_factor.compat import text_type
 from two_factor.gateways.fake import Fake
 from two_factor.gateways.twilio.gateway import Twilio
-from two_factor.models import PhoneDevice
+from two_factor.models import PhoneDevice, phone_number_validator
 from two_factor.utils import backup_phones, default_device, get_otpauth_url
 
 
@@ -474,8 +476,19 @@ class PhoneSetupTest(OTPUserMixin, TestCase):
         self.assertEqual(len(phones), 1)
         self.assertEqual(phones[0].name, 'backup')
         self.assertEqual(phones[0].number, '+123456789')
-        self.assertEqual(phones[0].key, device.key)
 
+    @patch('two_factor.gateways.fake.Fake')
+    @override_settings(
+        TWO_FACTOR_SMS_GATEWAY='two_factor.gateways.fake.Fake',
+        TWO_FACTOR_CALL_GATEWAY='two_factor.gateways.fake.Fake',
+    )
+    def test_number_validation(self, fake):
+        response = self._post({'phone_setup_view-current_step': 'setup',
+                               'setup-number': '123',
+                               'setup-method': 'call'})
+        self.assertEqual(
+            response.context_data['wizard']['form'].errors,
+            {'number': [text_type(phone_number_validator.message)]})
 
 class PhoneDeleteTest(OTPUserMixin, TestCase):
     def setUp(self):
@@ -671,3 +684,28 @@ class UtilsTest(TestCase):
 
         self.assertEqual(len(phones), 1)
         self.assertEqual(phones[0].pk, backup.pk)
+
+
+class ValidatorsTest(TestCase):
+    def test_phone_number_validator_on_form_valid(self):
+        class TestForm(forms.Form):
+            number = forms.CharField(validators=[phone_number_validator])
+
+        form = TestForm({
+            'number': '+1234567890',
+        })
+
+        self.assertTrue(form.is_valid())
+
+    def test_phone_number_validator_on_form_invalid(self):
+        class TestForm(forms.Form):
+            number = forms.CharField(validators=[phone_number_validator])
+
+        form = TestForm({
+            'number': '123',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('number', form.errors)
+        self.assertEqual(form.errors['number'],
+                         [text_type(phone_number_validator.message)])

--- a/two_factor/compat.py
+++ b/two_factor/compat.py
@@ -176,3 +176,9 @@ else:
         A WizardView with pre-configured SessionStorage backend.
         """
         storage_name = 'two_factor.compat.SessionStorage'
+
+
+try:
+    from django.utils.six import text_type
+except ImportError:
+    text_type = unicode

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -14,6 +14,7 @@ from .gateways import make_call, send_sms
 
 
 phone_number_validator = RegexValidator(
+    code='invalid-phone-number',
     regex='^(\+|00)',
     message=_('Please enter a valid phone number, including your country code '
               'starting with + or 00.'),


### PR DESCRIPTION
`phone_number_validator` works well when validating from a model, but not
so well when validating from a form field. It uses the default code of
`invalid`, which the Django fields will map to a pre-defined error
message, ignoring the custom one given by the validator.

By setting a custom error code, this mapping won't happen, and the
validator's message will instead be used.
