### PR TITLE
Always cast the token to an int before verification

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -792,6 +792,15 @@ class PhoneDeviceTest(UserMixin, TestCase):
         self.assertFalse(device.verify_token(-1))
         self.assertTrue(device.verify_token(totp(device.bin_key)))
 
+    def test_verify_token_as_string(self):
+        """
+        The field used to read the token may be a CharField,
+        so the PhoneDevice must be able to validate tokens
+        read as strings
+        """
+        device = PhoneDevice(key=random_hex().decode())
+        self.assertTrue(device.verify_token(str(totp(device.bin_key))))
+
     def test_unicode(self):
         device = PhoneDevice(name='unknown')
         self.assertEqual('unknown (None)', str(device))

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -89,6 +89,11 @@ class PhoneDevice(Device):
         return unhexlify(self.key.encode())
 
     def verify_token(self, token):
+        try:
+            token = int(token)
+        except ValueError:
+            return False
+
         for drift in range(-5, 1):
             if totp(self.bin_key, drift=drift) == token:
                 return True


### PR DESCRIPTION
If the field used to input the token is a CharField, the token value will be a string, and `PhoneDevice.verify_token` will always fail.

Casting the token to an int during the verification in order to avoid this problem. This is the same approach taken by django_otp.
