### PR TITLE
Modified string format to allow for proper i18n.

### DIFF
--- a/two_factor/gateways/twilio/gateway.py
+++ b/two_factor/gateways/twilio/gateway.py
@@ -55,7 +55,7 @@ class Twilio(object):
                                  url=uri, method='GET', if_machine='Hangup', timeout=15)
 
     def send_sms(self, device, token):
-        body = ugettext('Your authentication token is %s' % token)
+        body = ugettext('Your authentication token is %s') % token
         self.client.sms.messages.create(
             to=device.number,
             from_=getattr(settings, 'TWILIO_CALLER_ID'),


### PR DESCRIPTION
The string format used for SMS messages in the default Twilio gateway was wrong. This worked fine for english, but broke i18n.
