### PR TITLE
Make compatible with Django 1.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.1a
 files = setup.py docs/conf.py
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ copyright = '2014, Bouke Haarsma'
 #
 
 # The full version, including alpha/beta/rc tags.
-release = '1.1.1'
+release = '1.1.1a'
 
 # The short X.Y version.
 version = '.'.join(release.split('.')[0:2])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-two-factor-auth',
-    version='1.1.1',
+    version='1.1.1a',
     description='Complete Two-Factor Authentication for Django',
     long_description=open('README.rst').read(),
     author='Bouke Haarsma',
@@ -12,9 +12,10 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
-        'Django>=1.4.2,<1.8',
+        'Django>=1.4.2,<1.9',
         'django_otp>=0.2.0,<0.3.0',
         'qrcode>=4.0.0,<5.0.0',
+        'django_formtools==1.0',
     ],
     include_package_data=True,
     classifiers=[

--- a/two_factor/compat.py
+++ b/two_factor/compat.py
@@ -2,9 +2,9 @@ import django
 
 
 if django.VERSION[:2] >= (1, 6):
-    from django.contrib.formtools.wizard.views import WizardView
-    from django.contrib.formtools.wizard.views import SessionWizardView
-    from django.contrib.formtools.wizard.storage.session import SessionStorage
+    from formtools.wizard.views import WizardView
+    from formtools.wizard.views import SessionWizardView
+    from formtools.wizard.storage.session import SessionStorage
     from django.utils.http import is_safe_url
     from django.utils.module_loading import import_by_path
 
@@ -22,8 +22,8 @@ else:
     from django.utils.importlib import import_module
     from django.utils.datastructures import SortedDict
 
-    from django.contrib.formtools.wizard.storage.exceptions import NoFileStorageConfigured
-    from django.contrib.formtools.wizard.views import WizardView as _WizardView
+    from formtools.wizard.storage.exceptions import NoFileStorageConfigured
+    from formtools.wizard.views import WizardView as _WizardView
 
 
     # Fix for Django 1.4 and 1.5 which don't allow setting form_list etc on the
@@ -152,15 +152,15 @@ else:
 
 
 if (1, 5) <= django.VERSION[:2] < (1, 6):
-    from django.contrib.formtools.wizard.storage.session import SessionStorage
+    from formtools.wizard.storage.session import SessionStorage
 
     # Need to override SessionWizardView to subclass from the backported
     # WizardView.
     class SessionWizardView(WizardView):
-        storage_name = 'django.contrib.formtools.wizard.storage.session.SessionStorage'
+        storage_name = 'formtools.wizard.storage.session.SessionStorage'
 
 else:
-    from django.contrib.formtools.wizard.storage.session import SessionStorage as _SessionStorage
+    from formtools.wizard.storage.session import SessionStorage as _SessionStorage
     from django.core import urlresolvers
 
     # Fix for Django 1.4 -- it does `return .. or {}`, which makes working with

--- a/two_factor/views/utils.py
+++ b/two_factor/views/utils.py
@@ -1,5 +1,5 @@
 import logging
-from django.contrib.formtools.wizard.forms import ManagementForm
+from formtools.wizard.forms import ManagementForm
 from django.core.exceptions import ValidationError
 from django.utils.decorators import method_decorator
 from django.utils.functional import lazy_property


### PR DESCRIPTION
Patch imports and setup to use django-formtools instead of the obsolete contrib package.

This fixes issue https://github.com/Bouke/django-two-factor-auth/issues/89

Passed all tests in my environment.