### PR TITLE
Python 3.4 and Django 1.4/1.9 compatibility fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+example/database.sqlite
 example/settings_private.py
 *.egg-info
 /.coverage.*

--- a/docs/implementing.rst
+++ b/docs/implementing.rst
@@ -78,8 +78,8 @@ When a user was successfully verified using a OTP, the signal
 user, the device used and the request itself. You can use this signal for
 example to warn a user when one of his backup tokens was used::
 
-    from django.contrib.sites.models import get_current_site
     from django.dispatch import receiver
+    from two_factor.compat import get_current_site
     from two_factor.signals import user_verified
 
 

--- a/example/settings.py
+++ b/example/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = (
     'django_otp',
     'django_otp.plugins.otp_static',
     'django_otp.plugins.otp_totp',
+    'otp_yubikey',
     'two_factor',
     'example',
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ setup(
         'django_otp>=0.2.0,<0.2.99',
         'qrcode>=4.0.0,<4.99',
     ],
+    extras_require={
+        'Call': ['twilio'],
+        'SMS': ['twilio'],
+        'YubiKey': ['django-otp-yubikey'],
+    },
     include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1096,7 +1096,8 @@ class YubiKeyTest(UserMixin, TestCase):
         self.assertContains(response, 'YubiKey')
 
         # Without ValidationService it won't work
-        with self.assertRaisesMessage(KeyError, "No ValidationService found with name 'default'"):
+        with six.assertRaisesRegex(self, KeyError,
+                                   "No ValidationService found with name 'default'"):
                 self.client.post(reverse('two_factor:setup'),
                                  data={'setup_view-current_step': 'method',
                                        'method-method': 'yubikey'})

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1010,11 +1010,17 @@ class DisableCommandTest(UserMixin, TestCase):
             return self.assertRaises(SystemExit)
 
     def test_raises(self):
+        stdout = six.StringIO()
+        stderr = six.StringIO()
         with self._assert_raises(CommandError, 'User "some_username" does not exist'):
-            call_command('two_factor_disable', 'some_username')
+            call_command(
+                'two_factor_disable', 'some_username',
+                stdout=stdout, stderr=stderr)
 
         with self._assert_raises(CommandError, 'User "other_username" does not exist'):
-            call_command('two_factor_disable', 'other_username', 'some_username')
+            call_command(
+                'two_factor_disable', 'other_username', 'some_username',
+                stdout=stdout, stderr=stderr)
 
     def test_disable_single(self):
         user = self.create_user()
@@ -1044,11 +1050,17 @@ class StatusCommandTest(UserMixin, TestCase):
         os.environ['DJANGO_COLORS'] = 'nocolor'
 
     def test_raises(self):
+        stdout = six.StringIO()
+        stderr = six.StringIO()
         with self._assert_raises(CommandError, 'User "some_username" does not exist'):
-            call_command('two_factor_status', 'some_username')
+            call_command(
+                'two_factor_status', 'some_username',
+                stdout=stdout, stderr=stderr)
 
         with self._assert_raises(CommandError, 'User "other_username" does not exist'):
-            call_command('two_factor_status', 'other_username', 'some_username')
+            call_command(
+                'two_factor_status', 'other_username', 'some_username',
+                stdout=stdout, stderr=stderr)
 
     def test_status_single(self):
         user = self.create_user()

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ whitelist_externals = make
 
 [testenv:py26-django14]
 basepython = python2.6
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate = True
 deps =
     Django>=1.4,<1.5
     unittest2
@@ -48,6 +50,8 @@ deps =
 
 [testenv:py26-django14-yubikey]
 basepython = python2.6
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate = True
 deps =
     Django>=1.4,<1.5
     django-otp-yubikey
@@ -56,12 +60,16 @@ deps =
 
 [testenv:py27-django14]
 basepython = python2.7
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate = True
 deps =
     Django>=1.4,<1.5
     {[testenv]deps}
 
 [testenv:py27-django14-yubikey]
 basepython = python2.7
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate = True
 deps =
     Django>=1.4,<1.5
     django-otp-yubikey

--- a/two_factor/compat.py
+++ b/two_factor/compat.py
@@ -17,19 +17,13 @@ except ImportError:
     from django.contrib.sites.models import get_current_site
 
 if django.VERSION[:2] >= (1, 8):
-    from django.utils.http import is_safe_url
     from django.utils.module_loading import import_by_path
 
 elif django.VERSION[:2] >= (1, 6):
-    from django.utils.http import is_safe_url
     from django.utils.module_loading import import_by_path
 
 else:
     import sys
-    try:
-        from urllib.parse import urlparse
-    except ImportError:
-        from urlparse import urlparse
 
     from django import forms
     from django.core.exceptions import ImproperlyConfigured
@@ -127,20 +121,6 @@ else:
                 data=self.storage.get_step_data(self.steps.current),
                 files=self.storage.get_step_files(self.steps.current))
             return self.render(form)
-
-
-    def is_safe_url(url, host=None):
-        """
-        Return ``True`` if the url is a safe redirection (i.e. it doesn't point to
-        a different host and uses a safe scheme).
-
-        Always returns ``False`` on an empty url.
-        """
-        if not url:
-            return False
-        url_info = urlparse(url)
-        return (not url_info.netloc or url_info.netloc == host) and \
-               (not url_info.scheme or url_info.scheme in ['http', 'https'])
 
 
     def import_by_path(dotted_path, error_prefix=''):

--- a/two_factor/compat.py
+++ b/two_factor/compat.py
@@ -11,6 +11,10 @@ except ImportError:
     from django.contrib.formtools.wizard.views import SessionWizardView
     from django.contrib.formtools.wizard.storage.session import SessionStorage
 
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:
+    from django.contrib.sites.models import get_current_site
 
 if django.VERSION[:2] >= (1, 8):
     from django.utils.http import is_safe_url

--- a/two_factor/compat.py
+++ b/two_factor/compat.py
@@ -11,14 +11,14 @@ except ImportError:
     from django.contrib.formtools.wizard.views import SessionWizardView
     from django.contrib.formtools.wizard.storage.session import SessionStorage
 
-try:
+if django.VERSION[:2] >= (1, 7):
     from django.contrib.sites.shortcuts import get_current_site
-except ImportError:
+else:
     from django.contrib.sites.models import get_current_site
 
-try:
+if django.VERSION[:2] >= (1, 7):
     from django.utils.module_loading import import_string
-except ImportError:
+else:
     import sys
     from django.utils.importlib import import_module
     from django.utils import six

--- a/two_factor/gateways/__init__.py
+++ b/two_factor/gateways/__init__.py
@@ -1,9 +1,9 @@
 from django.conf import settings
-from ..compat import import_by_path
+from ..compat import import_string
 
 
 def get_gateway_class(import_path):
-    return import_by_path(import_path)
+    return import_string(import_path)
 
 
 def make_call(device, token):

--- a/two_factor/gateways/twilio/views.py
+++ b/two_factor/gateways/twilio/views.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.sites.models import get_current_site
 from django.http import HttpResponse
 from django.utils import translation
 from django.utils.translation import (ugettext_lazy as _, pgettext,
@@ -9,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 from .gateway import validate_voice_locale
+from ...compat import get_current_site
 from ...views.utils import class_view_decorator
 
 

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib.auth import login as login, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.sites.models import get_current_site
 from django.core.urlresolvers import reverse
 from django.forms import Form
 from django.http import HttpResponse, Http404
@@ -31,6 +30,7 @@ import qrcode
 import qrcode.image.svg
 
 from ..compat import is_safe_url, import_by_path
+from ..compat import get_current_site
 from ..forms import (MethodForm, TOTPDeviceForm, PhoneNumberMethodForm,
                      DeviceValidationForm, AuthenticationTokenForm,
                      PhoneNumberForm, BackupTokenForm, YubiKeyDeviceForm)

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.forms import Form
 from django.http import HttpResponse, Http404
 from django.shortcuts import redirect
+from django.utils.http import is_safe_url
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import FormView, DeleteView, TemplateView
@@ -29,7 +30,7 @@ except ImportError:
 import qrcode
 import qrcode.image.svg
 
-from ..compat import is_safe_url, import_by_path
+from ..compat import import_by_path
 from ..compat import get_current_site
 from ..forms import (MethodForm, TOTPDeviceForm, PhoneNumberMethodForm,
                      DeviceValidationForm, AuthenticationTokenForm,

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -30,7 +30,7 @@ except ImportError:
 import qrcode
 import qrcode.image.svg
 
-from ..compat import import_by_path
+from ..compat import import_string
 from ..compat import get_current_site
 from ..forms import (MethodForm, TOTPDeviceForm, PhoneNumberMethodForm,
                      DeviceValidationForm, AuthenticationTokenForm,
@@ -495,7 +495,7 @@ class QRGeneratorView(View):
 
         # Get data for qrcode
         image_factory_string = getattr(settings, 'TWO_FACTOR_QR_FACTORY', self.default_qr_factory)
-        image_factory = import_by_path(image_factory_string)
+        image_factory = import_string(image_factory_string)
         content_type = self.image_content_types[image_factory.kind]
         try:
             username = self.request.user.get_username()


### PR DESCRIPTION
All tox tests/environments pass. There are still some RemovedInDjango19Warnings remaining, mostly due to project dependencies:

```
.tox/py34-django18-custom_user/lib/python3.4/site-packages/django_otp/__init__.py:115:
RemovedInDjango19Warning: django.db.models.get_apps is deprecated.
  for app in get_apps():

.tox/py34-django18-custom_user/lib/python3.4/importlib/_bootstrap.py:321:
RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  return f(*args, **kwds)

.tox/py34-django18-custom_user/lib/python3.4/site-packages/django/db/models/__init__.py:56:
RemovedInDjango19Warning: [a.models_module for a in get_app_configs()] supersedes get_apps().
  return getattr(loading, function_name)(*args, **kwargs)

.tox/py34-django18-custom_user/lib/python3.4/site-packages/django_otp/__init__.py:116:
RemovedInDjango19Warning: django.db.models.get_models is deprecated.
  for model in get_models(app):

.tox/py34-django18-custom_user/lib/python3.4/functools.py:448: RemovedInDjango19Warning:
The app_mod argument of get_models is deprecated.
  result = user_function(*args, **kwds)

.tox/py34-django18-custom_user/lib/python3.4/site-packages/django/templatetags/future.py:25:
RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
  RemovedInDjango19Warning)
```