### PR TITLE
Add ThreadLocals middleware to documentation.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,6 +82,20 @@ base urlpatterns, like so::
         url(r'', include(tf_urls + tf_twilio_urls, 'two_factor')),
     )
 
+Additionally, you need to enable the``ThreadLocals`` middleware::
+
+    MIDDLEWARE_CLASSES = (
+        ...
+
+        # Always include for two-factor auth
+        'django_otp.middleware.OTPMiddleware',
+
+        # Include for twilio gateway
+        'two_factor.middleware.threadlocals.ThreadLocals',
+    )
+
+
+
 .. autoclass:: two_factor.gateways.twilio.gateway.Twilio
 
 Fake Gateway


### PR DESCRIPTION
Add documentation for the additional middleware required to use the Twilio gateway for voice.