### PR TITLE
Improve validation of phone numbers

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,9 @@ django_otp
 qrcode
 # django-formtools on Django 1.8 and above
 
+# Optional - improves phone number validation.
+phonenumbers
+
 # Example app
 
 django-debug-toolbar

--- a/two_factor/migrations/0003_auto_20150806_2156.py
+++ b/two_factor/migrations/0003_auto_20150806_2156.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import two_factor.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('two_factor', '0002_auto_20150110_0810'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='phonedevice',
+            name='number',
+            field=models.CharField(max_length=16, verbose_name='number', validators=[two_factor.models.phone_number_validator]),
+        ),
+    ]

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -28,11 +28,11 @@ if phonenumbers:
         try:
             num = phonenumbers.parse(phone_number, None)
             if not phonenumbers.is_valid_number(num):
-                raise ValidationError(_('Please enter a valid phone number, including your country code '
-                                        'starting with + or 00.'))
+                raise ValidationError(_('Please enter a valid phone number, including '
+                                        'your country code  starting with + or 00.'))
         except phonenumbers.phonenumberutil.NumberParseException:
-            raise ValidationError(_('Please enter a valid phone number, including your country code '
-                                    'starting with + or 00.'))
+            raise ValidationError(_('Please enter a valid phone number, including '
+                                    'your country code starting with + or 00.'))
 
 else:
     phone_number_validator = RegexValidator(

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -2,6 +2,7 @@ from binascii import unhexlify
 import logging
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -25,7 +26,10 @@ logger = logging.getLogger(__name__)
 if phonenumbers:
     def phone_number_validator(phone_number):
         try:
-            phonenumbers.parse(phone_number, None)
+            num = phonenumbers.parse(phone_number, None)
+            if not phonenumbers.is_valid_number(num):
+                raise ValidationError(_('Please enter a valid phone number, including your country code '
+                                        'starting with + or 00.'))
         except phonenumbers.phonenumberutil.NumberParseException:
             raise ValidationError(_('Please enter a valid phone number, including your country code '
                                     'starting with + or 00.'))


### PR DESCRIPTION
Use `phonenumbers` to validate phone numbers so that things like '+10' and '003' as well as things like '+123456789100' (too many digits) are not allowed. This used to cause a twilio error, now it returns a nice message. When `phonenumbers` is not installed, revert to the old method of validation.