### PR TITLE
Avoid possible staff user / adminsite DoS on sites with many users

### DIFF
--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -76,4 +76,12 @@ if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
     patch_admin()
 
 
-admin.site.register(PhoneDevice)
+class PhoneDeviceAdmin(admin.ModelAdmin):
+    """
+    :class:`~django.contrib.admin.ModelAdmin` for
+    :class:`~two_factor.models.PhoneDevice`.
+    """
+    raw_id_fields = ('user',)
+
+
+admin.site.register(PhoneDevice, PhoneDeviceAdmin)


### PR DESCRIPTION
...(loading all usernames / user_ids into memory to build the HTML dropdown list) by using raw_id_fields like python-social-auth does.

https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields
https://github.com/omab/python-social-auth/blob/v0.2.12/social/apps/django_app/default/admin.py#L14

See also django-otp which had a similar admin site issue: 
https://bitbucket.org/psagers/django-otp/pull-requests/14/avoid-possible-staff-user-adminsite-dos-in/diff