### PR TITLE
setup.py: pip install_requires breaks with * wildcard blacklist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
-        'Django>=1.4.2,<1.8.99,!=1.5.*,!=1.6.*',
+        'Django>=1.4.2,<1.8.99,!=1.5,!=1.5.12,!=1.6,!=1.6.11',
         'django_otp>=0.2.0,<0.2.99',
         'qrcode>=4.0.0,<4.99',
     ],


### PR DESCRIPTION
Possible compromise - blacklist first and last unsupported Django version from each stable/1.5.x and stable/1.6.x branch. 

Feel free to research for other fixes or get it fixed in a new pip, have not looked to see if there is an issue for this blacklist wildcard syntax.