### PR TITLE
Tox: Use generative envlist & conditional settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,229 +1,47 @@
 [tox]
+; Minimum version of Tox
+minversion = 1.8
 envlist =
-    py26-django14,
-    py27-django14,
-    py26-django14-yubikey,
-    py27-django14-yubikey,
+    py{26,27}-django14,
+    py{26,27}-django14-yubikey,
 
-    py27-django17,
-    py32-django17,
-    py33-django17,
-    py34-django17,
-    py27-django17-custom_user,
-    py32-django17-custom_user,
-    py33-django17-custom_user,
-    py34-django17-custom_user,
+    py{27,32,33,34}-django17,
+    py{27,32,33,34}-django17-custom_user,
 
-    py27-django18,
-    py32-django18,
-    py33-django18,
-    py34-django18,
-    py27-django18-yubikey,
-    py32-django18-yubikey,
-    py33-django18-yubikey,
-    py34-django18-yubikey,
-    py27-django18-custom_user,
-    py32-django18-custom_user,
-    py33-django18-custom_user,
-    py34-django18-custom_user,
+    py{27,32,33,34}-django18,
+    py{27,32,33,34}-django18-yubikey,
+    py{27,32,33,34}-django18-custom_user,
 
     flake8
 
 [testenv]
 commands = make test
+setenv =
+    custom_user: AUTH_USER_MODEL = tests.User
 deps =
     mock
     twilio
     qrcode
+    py26: unittest2
+    django14: Django>=1.4,<1.5
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django18: django-formtools
+    yubikey: django-otp-yubikey
+    flake8: flake8
 whitelist_externals = make
 
-; Django 1.4
-
 [testenv:py26-django14]
-basepython = python2.6
 install_command = pip install --no-binary=Django {opts} {packages}
-deps =
-    Django>=1.4,<1.5
-    unittest2
-    {[testenv]deps}
 
 [testenv:py26-django14-yubikey]
-basepython = python2.6
 install_command = pip install --no-binary=Django {opts} {packages}
-deps =
-    Django>=1.4,<1.5
-    django-otp-yubikey
-    unittest2
-    {[testenv]deps}
 
 [testenv:py27-django14]
-basepython = python2.7
 install_command = pip install --no-binary=Django {opts} {packages}
-deps =
-    Django>=1.4,<1.5
-    {[testenv]deps}
 
 [testenv:py27-django14-yubikey]
-basepython = python2.7
 install_command = pip install --no-binary=Django {opts} {packages}
-recreate = True
-deps =
-    Django>=1.4,<1.5
-    django-otp-yubikey
-    {[testenv]deps}
-
-
-; Django 1.7
-
-[testenv:py27-django17]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-
-[testenv:py32-django17]
-basepython = python3.2
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-
-[testenv:py33-django17]
-basepython = python3.3
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-
-[testenv:py34-django17]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-
-[testenv:py27-django17-custom_user]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py32-django17-custom_user]
-basepython = python3.2
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py33-django17-custom_user]
-basepython = python3.3
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py34-django17-custom_user]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.7.99
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-; Django 1.8
-
-[testenv:py27-django18]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-
-[testenv:py32-django18]
-basepython = python3.2
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-
-[testenv:py33-django18]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-
-[testenv:py34-django18]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-
-[testenv:py27-django18-yubikey]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    django-otp-yubikey
-    {[testenv]deps}
-
-[testenv:py32-django18-yubikey]
-basepython = python3.2
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    django-otp-yubikey
-    {[testenv]deps}
-
-[testenv:py33-django18-yubikey]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    django-otp-yubikey
-    {[testenv]deps}
-
-[testenv:py34-django18-yubikey]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    django-otp-yubikey
-    {[testenv]deps}
-
-[testenv:py27-django18-custom_user]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py32-django18-custom_user]
-basepython = python3.2
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py33-django18-custom_user]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-[testenv:py34-django18-custom_user]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.8.99
-    django-formtools
-    {[testenv]deps}
-setenv = AUTH_USER_MODEL = tests.User
-
-; flake8 (PEP 8)
 
 [testenv:flake8]
 commands = make flake8
-deps =
-    flake8


### PR DESCRIPTION
This simplifies tox.ini by
 - using a generative `envlist`
 - configuring environments based on "factors" such as `py26` & `django18`
 - removing `basepython` overrides, which just replicated Tox defaults
 - replacing e.g. `Django>=1.7,<1.7.99` deps with `Django>=1.7,<1.8`

I've diffed the generated list of environments against the original, and they're identical. It's worth noting Django 1.7 isn't tested with yubikey - I've left it as is.

`install_command` cannot use conditional settings, so it's left as is.

Generative envlist were first added to Tox 1.8.0, released 24 Sept 2014.

See also:
 - https://testrun.org/tox/latest/config.html#generating-environments-conditional-settings