### PR TITLE
Import Device from models

### DIFF
--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -6,7 +6,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from django_otp import Device
+from django_otp.models import Device
 from django_otp.oath import totp
 from django_otp.util import hex_validator, random_hex
 


### PR DESCRIPTION
This is related to django 1.9 compatibility and this [pull request.](https://bitbucket.org/psagers/django-otp/pull-requests/15/django-18-forbids-importing-models-in-the)