### PR TITLE
Changed to Django's LOGIN_URL

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -960,8 +960,8 @@ class UtilsTest(UserMixin, TestCase):
         self.assertEqual(lhs.path, rhs.path)
         self.assertEqual(lhs.fragment, rhs.fragment)
 
-        # We used parse_qs before, but as query parameter order became 
-        # significant with Microsoft Authenticator and possibly other 
+        # We used parse_qs before, but as query parameter order became
+        # significant with Microsoft Authenticator and possibly other
         # authenticator apps, we've switched to parse_qsl.
         self.assertEqual(parse_qsl(lhs.query), parse_qsl(rhs.query))
 

--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -39,7 +39,7 @@ class AdminSiteOTPRequiredMixin(object):
         else:
             url = request.get_full_path()
         return redirect('%s?%s' % (
-            reverse(settings.LOGIN_URL),
+            settings.LOGIN_URL,
             urlencode({REDIRECT_FIELD_NAME: url})
         ))
 
@@ -62,7 +62,7 @@ def patch_admin():
         else:
             url = request.get_full_path()
         return redirect('%s?%s' % (
-            reverse(settings.LOGIN_URL),
+            settings.LOGIN_URL,
             urlencode({REDIRECT_FIELD_NAME: url})
         ))
 

--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 
 from .utils import monkeypatch_method

--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -39,7 +39,7 @@ class AdminSiteOTPRequiredMixin(object):
         else:
             url = request.get_full_path()
         return redirect('%s?%s' % (
-            reverse('two_factor:login'),
+            reverse(settings.LOGIN_URL),
             urlencode({REDIRECT_FIELD_NAME: url})
         ))
 
@@ -62,7 +62,7 @@ def patch_admin():
         else:
             url = request.get_full_path()
         return redirect('%s?%s' % (
-            reverse('two_factor:login'),
+            reverse(settings.LOGIN_URL),
             urlencode({REDIRECT_FIELD_NAME: url})
         ))
 


### PR DESCRIPTION
If someone customizes the project and/or has default namespace currently this fails. This does allow customization.