### PR TITLE
Add compatibility with Django 1.9 and Python 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,19 @@ matrix:
       env: DJANGO=1.8
     - python: "2.7"
       env: DJANGO=1.8 AUTH_USER_MODEL=tests.User
-    - python: "3.4"
+    - python: "3.5"
       env: DJANGO=1.8 COVERAGE=YES
-    - python: "3.4"
+    - python: "3.5"
       env: DJANGO=1.8 AUTH_USER_MODEL=tests.User YUBIKEY=YES COVERAGE=YES
+
+    - python: "2.7"
+      env: DJANGO=1.9
+    - python: "2.7"
+      env: DJANGO=1.9 AUTH_USER_MODEL=tests.User
+    - python: "3.5"
+      env: DJANGO=1.9 COVERAGE=YES
+    - python: "3.5"
+      env: DJANGO=1.9 AUTH_USER_MODEL=tests.User YUBIKEY=YES COVERAGE=YES
 
     - python: "3.4"
       env: FLAKE8=YES
@@ -26,10 +35,13 @@ matrix:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
   - if [[ $DJANGO ]]; then
-        if [[ $DJANGO != 1.9* ]]; then
+        if [[ $DJANGO != 1.10* ]]; then
             pip install "django>=$DJANGO,<=$DJANGO.99";
         fi;
         if [[ $DJANGO == 1.8 ]]; then
+            pip install django-formtools;
+        fi;
+        if [[ $DJANGO == 1.9 ]]; then
             pip install django-formtools;
         fi;
         pip install twilio==3.6.8 qrcode;

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth.views import logout
 
 from two_factor.urls import urlpatterns as tf_urls
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
@@ -18,7 +19,7 @@ urlpatterns = [
     ),
     url(
         regex=r'^account/logout/$',
-        view='django.contrib.auth.views.logout',
+        view=logout,
         name='logout',
     ),
     url(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
-        'Django>=1.7,<1.8.99',
+        'Django>=1.7,<1.9.99',
         'django_otp>=0.2.0,<0.99',
         'qrcode>=4.0.0,<4.99',
         'phonenumbers>=7.0.9,<7.99',
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Security',
         'Topic :: System :: Systems Administration :: Authentication/Directory',
     ],

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -54,10 +54,32 @@ DATABASES = {
     }
 }
 
+# Django < 1.8
 TEMPLATE_DIRS = (
     os.path.join(BASE_DIR, 'templates'),
 )
 
+# Django >= 1.8
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(BASE_DIR, 'templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 TWO_FACTOR_PATCH_ADMIN = False
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -532,8 +532,8 @@ class OTPRequiredMixinTest(UserMixin, TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(ROOT_URLCONF='tests.urls_admin')
 class AdminPatchTest(TestCase):
-    urls = 'tests.urls_admin'
 
     def setUp(self):
         patch_admin()
@@ -548,8 +548,8 @@ class AdminPatchTest(TestCase):
         self.assertRedirects(response, redirect_to)
 
 
+@override_settings(ROOT_URLCONF='tests.urls_admin')
 class AdminSiteTest(UserMixin, TestCase):
-    urls = 'tests.urls_admin'
 
     def setUp(self):
         super(AdminSiteTest, self).setUp()
@@ -561,8 +561,8 @@ class AdminSiteTest(UserMixin, TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(ROOT_URLCONF='tests.urls_otp_admin')
 class OTPAdminSiteTest(UserMixin, TestCase):
-    urls = 'tests.urls_otp_admin'
 
     def setUp(self):
         super(OTPAdminSiteTest, self).setUp()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url, include
+from django.contrib.auth.views import logout
 
 from two_factor.views import LoginView
 from two_factor.urls import urlpatterns as tf_urls
@@ -10,7 +11,7 @@ from .views import SecureView
 urlpatterns = [
     url(
         regex=r'^account/logout/$',
-        view='django.contrib.auth.views.logout',
+        view=logout,
         name='logout',
     ),
     url(

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,13 @@ envlist =
     py{27,32,33,34}-django17,
     py{27,32,33,34}-django17-custom_user,
 
-    py{27,32,33,34}-django18,
-    py{27,32,33,34}-django18-yubikey,
-    py{27,32,33,34}-django18-custom_user,
+    py{27,32,33,34,35}-django18,
+    py{27,32,33,34,35}-django18-yubikey,
+    py{27,32,33,34,35}-django18-custom_user,
+
+    py{27,34,35}-django19,
+    py{27,34,35}-django19-yubikey,
+    py{27,34,35}-django19-custom_user,
 
     flake8
 
@@ -22,7 +26,9 @@ deps =
     phonenumbers
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
     django18: django-formtools
+    django19: django-formtools
     yubikey: django-otp-yubikey
     flake8: flake8
 whitelist_externals = make

--- a/two_factor/apps.py
+++ b/two_factor/apps.py
@@ -1,13 +1,12 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-from .admin import patch_admin
-
 
 class TwoFactorConfig(AppConfig):
     name = 'two_factor'
     verbose_name = "Django Two Factor Authentication"
 
     def ready(self):
+        from .admin import patch_admin
         if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
             patch_admin()


### PR DESCRIPTION
This commit fixes deprecation warnings in a backwards-compatible way.