### PR TITLE
Added quotes to TWO_FACTOR_QR_FACTORY examples

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,8 +48,8 @@ General Settings
   on IE8 and below. If you have PIL, Pillow or pyimaging installed
   you may wish to use PNG images instead.
 
-  * ``qrcode.image.pil.PilImage`` may be used for PIL/Pillow
-  * ``qrcode.image.pure.PymagingImage`` may be used for pyimaging
+  * ``'qrcode.image.pil.PilImage'`` may be used for PIL/Pillow
+  * ``'qrcode.image.pure.PymagingImage'`` may be used for pyimaging
 
   For more QR factories that are available see python-qrcode_.
 


### PR DESCRIPTION
Added quotes to TWO_FACTOR_QR_FACTORY settings.py examples, to match other examples earlier in the document.