### PR TITLE
Check if prefix exists in session before trying to reset storage

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -314,6 +314,25 @@ class LoginTest(UserMixin, TestCase):
             "step in the wizard.",
             'token')
 
+    @patch('two_factor.views.utils.logger')
+    def test_login_different_user_on_existing_session(self, mock_logger):
+        """
+        This test reproduces the issue where a user is logged in and a different user
+        attempts to login.
+        """
+        self.create_user()
+        self.create_user(username='vedran@example.com')
+
+        response = self._post({'auth-username': 'bouke@example.com',
+                               'auth-password': 'secret',
+                               'login_view-current_step': 'auth'})
+        self.assertRedirects(response, str(settings.LOGIN_REDIRECT_URL))
+
+        response = self._post({'auth-username': 'vedran@example.com',
+                               'auth-password': 'secret',
+                               'login_view-current_step': 'auth'})
+        self.assertRedirects(response, str(settings.LOGIN_REDIRECT_URL))
+
 
 class SetupTest(UserMixin, TestCase):
     def setUp(self):

--- a/two_factor/views/utils.py
+++ b/two_factor/views/utils.py
@@ -28,6 +28,12 @@ class ExtraSessionStorage(SessionStorage):
         super(ExtraSessionStorage, self).init_data()
         self.data[self.validated_step_data_key] = {}
 
+    def reset(self):
+        if self.prefix in self.request.session:
+            super(ExtraSessionStorage, self).reset()
+        else:
+            self.init_data()
+
     def _get_validated_step_data(self):
         return self.data[self.validated_step_data_key]
 


### PR DESCRIPTION
This pull request addresses the error which occurs when attempting to login a user while another user is already logged in.
This problem is described in issue #102.