### PR TITLE
Skipping welcome page

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -204,7 +204,7 @@ class SetupView(IdempotentSessionWizardView):
     session_key_name = 'django_two_factor-qr_secret_key'
     initial_dict = {}
     form_list = (
-        ('welcome', Form),
+        #('welcome', Form),
         ('method', MethodForm),
         ('generator', TOTPDeviceForm),
         ('sms', PhoneNumberForm),


### PR DESCRIPTION
This edit is meant to allow user to skip the Welcome and the tfa authorization step.

The line ('Welcome', Form) has been commented out to skip the Welcome page and during the first login for tfa setup user is manually authenticated and then redirected to the setup page:

```
from django.contrib.auth import authenticate, login
user_auth = authenticate(username=username, password=pwsd)
login(request, user_auth)
return redirect('/account/two_factor/setup/') #user goes directly to setup page
```