### PR TITLE
TWO_FACTOR_SKIP_WELCOME setting to skip welcome page.

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -204,7 +204,7 @@ class SetupView(IdempotentSessionWizardView):
     template_name = 'two_factor/core/setup.html'
     session_key_name = 'django_two_factor-qr_secret_key'
     initial_dict = {}
-    form_list = (
+    form_list = [
         ('welcome', Form),
         ('method', MethodForm),
         ('generator', TOTPDeviceForm),
@@ -212,7 +212,11 @@ class SetupView(IdempotentSessionWizardView):
         ('call', PhoneNumberForm),
         ('validation', DeviceValidationForm),
         ('yubikey', YubiKeyDeviceForm),
-    )
+    ]
+    if hasattr(settings, 'TWO_FACTOR_SKIP_WELCOME') and settings.TWO_FACTOR_SKIP_WELCOME:
+        form_list.pop(0)
+    form_list = tuple(form_list)
+
     condition_dict = {
         'generator': lambda self: self.get_method() == 'generator',
         'call': lambda self: self.get_method() == 'call',


### PR DESCRIPTION
PR for issue #149 
TWO_FACTOR_SKIP_WELCOME = True in settings will drop welcome page from wizard.
If setting is left out it will continue to work as normal.

Unit tests all passing.