### PR TITLE
Upgrade phone number field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'django_otp>=0.3.4,<0.99',
         'qrcode>=4.0.0,<4.99',
         'phonenumbers>=7.0.9,<7.99',
-        'django-phonenumber-field>=0.7.2,<0.99',
+        'django-phonenumber-field>=1.1.0,<1.99.0',
         'django-formtools',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
         'Django>=1.8',
         'django_otp>=0.3.4,<0.99',
         'qrcode>=4.0.0,<4.99',
-        'phonenumbers>=7.0.9,<7.99',
-        'django-phonenumber-field>=1.1.0,<1.99.0',
+        'phonenumberslite>=7.0.9,<7.99',
+        'django-phonenumber-field>=1.1.0,<1.99',
         'django-formtools',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ deps =
     coverage
 
     django-formtools
-    django-phonenumber-field>=0.7.2,<0.99
+    django-phonenumber-field>=1.1.0,<1.99
     django_otp>=0.3.4,<0.99
-    phonenumbers>=7.0.9,<7.99
+    phonenumberslite>=7.0.9,<7.99
     qrcode>=4.0.0,<4.99
     twilio
 ignore_outcome =


### PR DESCRIPTION
@Bouke 

- Upgrades `phonenumberfield`
- Uses `phonenumberslite` by default (taken from https://github.com/stefanfoulis/django-phonenumber-field/blob/1.1.0/setup.py#L7-L8)
- Removes `debug_toolbar` from `INSTALLED_APPS` as it errors before running the server on django 1.10 due to middleware missing (https://github.com/Bouke/django-two-factor-auth/blob/543687e872bfe7a3d6244f8c73fb9149e53a1df9/example/settings.py#L33)