### PR TITLE
Fix #182: Autofocus token input during authentication

### DIFF
--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -142,6 +142,8 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, Form):
     otp_token = forms.IntegerField(label=_("Token"), min_value=1,
                                    max_value=int('9' * totp_digits()))
 
+    otp_token.widget.attrs.update({'autofocus': 'autofocus'})
+
     # Our authentication form has an additional submit button to go to the
     # backup token form. When the `required` attribute is set on an input
     # field, that button cannot be used on browsers that implement html5


### PR DESCRIPTION
Token input usually comes directly after user:pass input. The user
already has their hands on the keyboard and the token is the only field
for input in the wizard flow. It should auto focus, so no additional tab
or mouse clicks are necessary to complete authentication.

While this could be a template decision, since the authentication
workflow is wrapped in a wizard, I think changing the
AuthenticationTokenForm makes the most sense.