### PR TITLE
Fix failure if LOGIN_REDIRECT_URL is an URL

### DIFF
--- a/tests/test_views_phone.py
+++ b/tests/test_views_phone.py
@@ -6,7 +6,7 @@ except ImportError:
     import mock
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import resolve_url
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -99,7 +99,22 @@ class PhoneSetupTest(UserMixin, TestCase):
         url_name = 'two_factor:profile'
         url = reverse(url_name)
         view = PhoneSetupView()
-        view.success_url = url
+        view.success_url = url_name
+
+        def return_kwargs(form, **kwargs):
+            return kwargs
+        get_context_data.side_effect = return_kwargs
+
+        context = view.get_context_data(None)
+        self.assertIn('cancel_url', context)
+        self.assertEqual(url, context['cancel_url'])
+
+    @mock.patch('formtools.wizard.views.WizardView.get_context_data')
+    def test_success_url_as_reverse_lazy(self, get_context_data):
+        url_name = 'two_factor:profile'
+        url = reverse(url_name)
+        view = PhoneSetupView()
+        view.success_url = reverse_lazy(url_name)
 
         def return_kwargs(form, **kwargs):
             return kwargs
@@ -139,7 +154,14 @@ class PhoneDeleteTest(UserMixin, TestCase):
         url_name = 'two_factor:profile'
         url = reverse(url_name)
         view = PhoneDeleteView()
-        view.success_url = url
+        view.success_url = url_name
+        self.assertEqual(view.get_success_url(), url)
+
+    def test_success_url_as_reverse_lazy(self):
+        url_name = 'two_factor:profile'
+        url = reverse(url_name)
+        view = PhoneDeleteView()
+        view.success_url = reverse_lazy(url_name)
         self.assertEqual(view.get_success_url(), url)
 
 

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -11,7 +11,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.core.urlresolvers import reverse
 from django.forms import Form
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, resolve_url
@@ -424,7 +424,7 @@ class PhoneSetupView(IdempotentSessionWizardView):
     numbers can be used for verification.
     """
     template_name = 'two_factor/core/phone_register.html'
-    success_url = reverse_lazy(settings.LOGIN_REDIRECT_URL)
+    success_url = settings.LOGIN_REDIRECT_URL
     form_list = (
         ('setup', PhoneNumberMethodForm),
         ('validation', DeviceValidationForm),
@@ -481,7 +481,7 @@ class PhoneSetupView(IdempotentSessionWizardView):
         return self.storage.extra_data[self.key_name]
 
     def get_context_data(self, form, **kwargs):
-        kwargs.setdefault('cancel_url', self.success_url)
+        kwargs.setdefault('cancel_url', resolve_url(self.success_url))
         return super(PhoneSetupView, self).get_context_data(form, **kwargs)
 
 
@@ -491,10 +491,13 @@ class PhoneDeleteView(DeleteView):
     """
     View for removing a phone number used for verification.
     """
-    success_url = reverse_lazy(settings.LOGIN_REDIRECT_URL)
+    success_url = settings.LOGIN_REDIRECT_URL
 
     def get_queryset(self):
         return self.request.user.phonedevice_set.filter(name='backup')
+
+    def get_success_url(self):
+        return resolve_url(self.success_url)
 
 
 @class_view_decorator(never_cache)


### PR DESCRIPTION
If LOGIN_REDIRECT_URL is an URL (and not a named URL), adding or removing an backup phone will generate an error: ```Reverse for '/accounts/login/' with arguments '()' and keyword arguments '{}' not found. 0 pattern(s) tried: []```

This is due to PhoneSetupView and PhoneDeleteView that pass LOGIN_REDIRECT_URL to reverse_lazy. But reverse_lazy only works with an named URL or a view function.

To reproduce this issue, changing tests.settings.LOGIN_REDIRECT_URL from "two_factor:profile" to "/account/two_factor/" will reproduce this issue when running tests.