### PR TITLE
Remove Django 2.0 deprecation warnings [wip]

### DIFF
--- a/two_factor/gateways/twilio/gateway.py
+++ b/two_factor/gateways/twilio/gateway.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.utils import translation
 from django.utils.translation import pgettext, ugettext
 from twilio.rest import TwilioRestClient
 
 from two_factor.middleware.threadlocals import get_current_request
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 try:
     from urllib.parse import urlencode

--- a/two_factor/migrations/0001_initial.py
+++ b/two_factor/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('number', models.CharField(max_length=16, verbose_name='number', validators=[django.core.validators.RegexValidator(regex='^(\\+|00)', message='Please enter a valid phone number, including your country code starting with + or 00.', code=b'invalid-phone-number')])),
                 ('key', models.CharField(help_text=b'Hex-encoded secret key', max_length=40)),
                 ('method', models.CharField(max_length=4, verbose_name='method', choices=[(b'call', 'Phone Call'), (b'sms', 'Text Message')])),
-                ('user', models.ForeignKey(help_text=b'The user that this device belongs to.', to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(help_text=b'The user that this device belongs to.', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -11,7 +11,6 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse
 from django.forms import Form
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, resolve_url
@@ -36,6 +35,11 @@ from ..forms import (
 from ..models import PhoneDevice, get_available_phone_methods
 from ..utils import backup_phones, default_device, get_otpauth_url
 from .utils import IdempotentSessionWizardView, class_view_decorator
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 try:
     from otp_yubikey.models import ValidationService, RemoteYubikeyDevice

--- a/two_factor/views/mixins.py
+++ b/two_factor/views/mixins.py
@@ -1,10 +1,14 @@
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.template.response import TemplateResponse
 
 from ..utils import default_device
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 
 class OTPRequiredMixin(object):


### PR DESCRIPTION
* [x] `django.core.urlresolvers` -> `django.urls`
* [ ] upgrade django-formtools, when it is ready (also fixes deprecated imports https://github.com/django/django-formtools/commits/164f0f46e651292680204f3c2a1afbaf9b31085c)
* [X] add on_delete=models.CASCADE to migration for Django 2.0 compat