### PR TITLE
Fixed redirect_to after successful login

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -53,6 +53,15 @@ class LoginTest(UserMixin, TestCase):
              'login_view-current_step': 'auth'})
         self.assertRedirects(response, redirect_url)
 
+    def test_valid_login_with_custom_post_redirect(self):
+        redirect_url = reverse('two_factor:setup')
+        self.create_user()
+        response = self._post({'auth-username': 'bouke@example.com',
+                               'auth-password': 'secret',
+                               'login_view-current_step': 'auth',
+                               'next': redirect_url})
+        self.assertRedirects(response, redirect_url)
+
     def test_valid_login_with_redirect_field_name(self):
         redirect_url = reverse('two_factor:setup')
         self.create_user()

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -105,7 +105,10 @@ class LoginView(IdempotentSessionWizardView):
         """
         login(self.request, self.get_user())
 
-        redirect_to = self.request.GET.get(self.redirect_field_name, '')
+        redirect_to = self.request.POST.get(
+            self.redirect_field_name,
+            self.request.GET.get(self.redirect_field_name, '')
+        )
         if not is_safe_url(url=redirect_to, host=self.request.get_host()):
             redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
 


### PR DESCRIPTION
The `redirect_to` was not working correctly on a successful POST request login. I updated the logic to be consistent with how Django does it. See [here](https://github.com/django/django/blob/master/django/contrib/auth/views.py#L69) as example to how Django handles getting `redirect_to` from params.