### PR TITLE
Fix Twilio v6 usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
         'django-formtools',
     ],
     extras_require={
-        'Call': ['twilio'],
-        'SMS': ['twilio'],
+        'Call': ['twilio>6.0'],
+        'SMS': ['twilio>6.0'],
         'YubiKey': ['django-otp-yubikey'],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
         'django-formtools',
     ],
     extras_require={
-        'Call': ['twilio>6.0'],
-        'SMS': ['twilio>6.0'],
+        'Call': ['twilio>=6.0'],
+        'SMS': ['twilio>=6.0'],
         'YubiKey': ['django-otp-yubikey'],
     },
     include_package_data=True,

--- a/tests/test_gateways.py
+++ b/tests/test_gateways.py
@@ -60,25 +60,25 @@ class TwilioGatewayTest(TestCase):
         for code in ['654321', '054321', '87654321', '07654321']:
             twilio.make_call(device=Mock(number=PhoneNumber.from_string('+123')), token=code)
             client.return_value.calls.create.assert_called_with(
-                from_='+456', to='+123', method='GET', if_machine='Hangup', timeout=15,
+                from_='+456', to='+123', method='GET', timeout=15,
                 url='http://testserver/twilio/inbound/two_factor/%s/?locale=en-us' % code)
 
             twilio.send_sms(device=Mock(number=PhoneNumber.from_string('+123')), token=code)
-            client.return_value.sms.messages.create.assert_called_with(
+            client.return_value.messages.create.assert_called_with(
                 to='+123', body='Your authentication token is %s' % code, from_='+456')
 
             client.return_value.calls.create.reset_mock()
             with translation.override('en-gb'):
                 twilio.make_call(device=Mock(number=PhoneNumber.from_string('+123')), token=code)
                 client.return_value.calls.create.assert_called_with(
-                    from_='+456', to='+123', method='GET', if_machine='Hangup', timeout=15,
+                    from_='+456', to='+123', method='GET', timeout=15,
                     url='http://testserver/twilio/inbound/two_factor/%s/?locale=en-gb' % code)
 
             client.return_value.calls.create.reset_mock()
             with translation.override('en-gb'):
                 twilio.make_call(device=Mock(number=PhoneNumber.from_string('+123')), token=code)
                 client.return_value.calls.create.assert_called_with(
-                    from_='+456', to='+123', method='GET', if_machine='Hangup', timeout=15,
+                    from_='+456', to='+123', method='GET', timeout=15,
                     url='http://testserver/twilio/inbound/two_factor/%s/?locale=en-gb' % code)
 
     @override_settings(

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99
     qrcode>=4.0.0,<4.99
-    twilio
+    twilio>6.0
 ignore_outcome =
     djmaster: True
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99
     qrcode>=4.0.0,<4.99
-    twilio>6.0
+    twilio>=6.0
 ignore_outcome =
     djmaster: True
 commands =

--- a/two_factor/gateways/twilio/gateway.py
+++ b/two_factor/gateways/twilio/gateway.py
@@ -59,11 +59,11 @@ class Twilio(object):
         uri = request.build_absolute_uri(url)
         self.client.calls.create(to=device.number.as_e164,
                                  from_=getattr(settings, 'TWILIO_CALLER_ID'),
-                                 url=uri, method='GET', if_machine='Hangup', timeout=15)
+                                 url=uri, method='GET', timeout=15)
 
     def send_sms(self, device, token):
         body = ugettext('Your authentication token is %s') % token
-        self.client.sms.messages.create(
+        self.client.messages.create(
             to=device.number.as_e164,
             from_=getattr(settings, 'TWILIO_CALLER_ID'),
             body=body)


### PR DESCRIPTION
- Twilio v6 library is backwards incompatible
- Machine detection has been changed to work based on Webhook, and rather than figure out appropriate response to hang up, I chose to disable machine detection.

Fixes Bouke/django-two-factor-auth#211