### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
-        'Django>=1.8,!=1.9.*',
+        'Django>=1.8,!=1.9',
         'django_otp>=0.3.4,<0.99',
         'qrcode>=4.0.0,<4.99',
         'django-phonenumber-field>=1.1.0,<1.99',


### PR DESCRIPTION
Fixes: `ValueError: ("Expected ',' or end-of-list in", 'Django >=1.8,!=1.9.*', 'at', '*')` when trying to install via pip.