### PR TITLE
Add reference to LOGIN_REDIRECT_URL to readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Configure a few urls in settings.py::
 
     from django.core.urlresolvers import reverse_lazy
     LOGIN_URL = 'two_factor:login'
+    LOGIN_REDIRECT_URL = 'two_factor:profile'
 
 Add the url routes to the project in urls.py::
 


### PR DESCRIPTION
## Description
The readme on github was missing a reference to LOGIN_REDIRECT_URL, as seen on readthedocs. I simply added the redirect url for new users of the repo.

## Motivation and Context
This change will help new users get the project running quicker.

## How Has This Been Tested?
No tests necessary

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
