### PR TITLE
Ensure yubikey token is not displayed on input

### DIFF
--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -73,7 +73,7 @@ class DeviceValidationForm(forms.Form):
 
 
 class YubiKeyDeviceForm(DeviceValidationForm):
-    token = forms.CharField(label=_("YubiKey"))
+    token = forms.CharField(label=_("YubiKey"), widget=forms.PasswordInput())
 
     error_messages = {
         'invalid_token': _("The YubiKey could not be verified."),
@@ -167,7 +167,7 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, Form):
         # IntegerField with a CharField.
         if RemoteYubikeyDevice and YubikeyDevice and \
                 isinstance(initial_device, (RemoteYubikeyDevice, YubikeyDevice)):
-            self.fields['otp_token'] = forms.CharField(label=_('YubiKey'))
+            self.fields['otp_token'] = forms.CharField(label=_('YubiKey'), widget=forms.PasswordInput())
 
     def clean(self):
         self.clean_otp(self.user)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Yubikey token should not be displayed on input. The form field should be treated as PasswordInput() rather than a normal text field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.