### PR TITLE
Added SMS message template in django settings for twilio

### DIFF
--- a/two_factor/gateways/twilio/gateway.py
+++ b/two_factor/gateways/twilio/gateway.py
@@ -63,6 +63,8 @@ class Twilio(object):
 
     def send_sms(self, device, token):
         body = ugettext('Your authentication token is %s') % token
+        if hasattr(settings, "TWILIO_SMS_BODY_TEXT"):
+            body = ugettext("%s %s") % (getattr(settings, 'TWILIO_SMS_BODY_TEXT'), token)
         self.client.messages.create(
             to=device.number.as_e164,
             from_=getattr(settings, 'TWILIO_CALLER_ID'),

--- a/two_factor/gateways/twilio/gateway.py
+++ b/two_factor/gateways/twilio/gateway.py
@@ -43,6 +43,11 @@ class Twilio(object):
       Should be set to a verified phone number. Twilio_ differentiates between
       numbers verified for making phone calls and sending text messages.
 
+    ``TWILIO_SMS_BODY_TEXT``
+      Should be set to text message suitable for your system. Please note the
+      total SMS length.
+      You should also replace the locale for different languages.
+      
     .. _Twilio: http://www.twilio.com/
     """
     def __init__(self):


### PR DESCRIPTION
Added reading text message body template from the django settings file (if specified). If not specified then the default value will be used

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enables the users to use django settings TWILIO_SMS_BODY_TEXT to have their own custom text message text. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At present the users cannot have their own custom text message while sending authentication messages
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
