### PR TITLE
Replace User.is_authenticated call with property

### DIFF
--- a/two_factor/utils.py
+++ b/two_factor/utils.py
@@ -73,3 +73,14 @@ def user_is_anonymous(user):
         return user.is_anonymous()
 
     return user.is_anonymous
+
+
+def user_is_authenticated(user):
+    if not user:
+        return False
+
+    # https://docs.djangoproject.com/en/dev/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods
+    if django.VERSION < (1, 10):
+        return user.is_authenticated()
+
+    return user.is_authenticated

--- a/two_factor/views/mixins.py
+++ b/two_factor/views/mixins.py
@@ -3,7 +3,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
 
-from ..utils import default_device
+from ..utils import default_device, user_is_authenticated
 
 try:
     from django.urls import reverse
@@ -59,7 +59,7 @@ class OTPRequiredMixin(object):
         return self.verification_url and str(self.verification_url)
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated() or \
+        if not user_is_authenticated(request.user) or \
                 (not request.user.is_verified() and default_device(request.user)):
             # If the user has not authenticated raise or redirect to the login
             # page. Also if the user just enabled two-factor authentication and


### PR DESCRIPTION
## Description
The method is deprecated and removed in Django 2.
It is replaced by the is_authenticated property.

Very similar to PR #230.

## Motivation and Context
This stops warnings being emitted on Django 1.10 and 1.11 and fixes compatibility with Django 2.x.

## How Has This Been Tested?
Tests run and passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
