### PR TITLE
Fix the wording in 2FA disable template

### DIFF
--- a/two_factor/templates/two_factor/profile/disable.html
+++ b/two_factor/templates/two_factor/profile/disable.html
@@ -4,7 +4,7 @@
 {% block content %}
   <h1>{% block title %}{% trans "Disable Two-factor Authentication" %}{% endblock %}</h1>
   <p>{% blocktrans %}You are about to disable two-factor authentication. This
-    compromises your account security, are you sure?{% endblocktrans %}</p>
+    weakens your account security, are you sure?{% endblocktrans %}</p>
   <form method="post">
     {% csrf_token %}
     <table>{{ form }}</table>


### PR DESCRIPTION
NOTE: I meant to open an issue about the wording, but figured out providing an example diff would be more helpful. Please don't be angry if the PR doesn't meet criteria necessary to merge it.

## Description
Change "compromises your account security" to "weakens your account security"
as disabling 2FA alone does not necessarily cause a security breach.

## Motivation and Context
The wording in the 2FA disable template is misleading.
One usually connects "compromises your account security"  with "security compromise" i.e. a security breach.
It makes it seem like you will get pwned the moment you disable 2FA, which, in most cases, is not true.

## How Has This Been Tested?
This is a simple change in wording, I don't think it needs testing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
