### PR TITLE
Support qrcode 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ example/settings_private.py
 /.tox/
 /htmlcov/
 /docs/_build/
+.eggs/

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Django>=1.11',
         'django_otp>=0.3.4,<0.99',
-        'qrcode>=4.0.0,<4.99',
+        'qrcode>=4.0.0,<5.99',
         'django-phonenumber-field>=1.1.0,<1.99',
         'django-formtools',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Django>=1.11',
         'django_otp>=0.3.4,<0.99',
-        'qrcode>=4.0.0,<5.99',
+        'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<1.99',
         'django-formtools',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     django-phonenumber-field>=0.7.2,<0.99
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99
-    qrcode>=4.0.0,<5.99
+    qrcode>=4.0.0,<6.99
     twilio>=6.0
 ignore_outcome =
     djmaster: True

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     django-phonenumber-field>=0.7.2,<0.99
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99
-    qrcode>=4.0.0,<4.99
+    qrcode>=4.0.0,<5.99
     twilio>=6.0
 ignore_outcome =
     djmaster: True


### PR DESCRIPTION
## Description
Allows using qrcode 4.x or 5.x with this library

## Motivation and Context
We originally had 5.3 installed and missed that it conflicted with this package. I believe that this could also be upgraded to 6.x, but I have not tested it.

This is the changelog in case you wish to review: https://github.com/lincolnloop/python-qrcode/blob/master/CHANGES.rst#53-18-may-2016

## How Has This Been Tested?
We've accidentally been running with qrcode==5.3 in production recently and this was only caught due to a warning pip 10.x gave us. I've upgrade the tests to install <5.99.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
