### PR TITLE
Update django-phonenumber-field dep and tox deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setup(
         'Django>=1.11',
         'django_otp>=0.3.4,<0.99',
         'qrcode>=4.0.0,<6.99',
-        'django-phonenumber-field>=1.1.0,<1.99',
+        'django-phonenumber-field>=1.1.0,<2.99',
         'django-formtools',
+        'phonenumbers>=7.0.9,<7.99',
     ],
     extras_require={
         'Call': ['twilio>=6.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     coverage
 
     django-formtools
-    django-phonenumber-field>=0.7.2,<0.99
+    django-phonenumber-field>=1.1.0,<2.99
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99
     qrcode>=4.0.0,<6.99


### PR DESCRIPTION
Bumping the requirements to `django-phonenumber-field<2.99` and updating the deps in tox. I removed `phonenumbers` from the tox deps as that is no longer a direct dependency.

I've run this with tox locally with the exception of the py34 environment.