### PR TITLE
Django 2.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,19 @@ matrix:
       env: DJANGO=2.0 VARIANT=custom_user
 
     - python: 3.5
+      env: DJANGO=2.1 VARIANT=normal
+    - python: 3.5
+      env: DJANGO=2.1 VARIANT=yubikey
+    - python: 3.5
+      env: DJANGO=2.1 VARIANT=custom_user
+    - python: 3.6
+      env: DJANGO=2.1 VARIANT=normal
+    - python: 3.6
+      env: DJANGO=2.1 VARIANT=yubikey
+    - python: 3.6
+      env: DJANGO=2.1 VARIANT=custom_user
+
+    - python: 3.5
       env: DJANGO=master VARIANT=normal
     - python: 3.5
       env: DJANGO=master VARIANT=yubikey

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import include, url
-from django.contrib.auth.views import logout
+from django.contrib.auth.views import LogoutView
 
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
@@ -10,7 +10,7 @@ from .views import SecureView
 urlpatterns = [
     url(
         regex=r'^account/logout/$',
-        view=logout,
+        view=LogoutView.as_view(),
         name='logout',
     ),
     url(

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ minversion = 1.8
 envlist =
     py{27,34,35,36}-dj111-{normal,yubikey,custom_user},
     py{34,35,36}-dj20-{normal,yubikey,custom_user},
+    py{35,36}-dj21-{normal,yubikey,custom_user},
     py{35,36}-djmaster-{normal,yubikey,custom_user},
     flake8
 skipsdist = True
@@ -15,6 +16,7 @@ unignore_outcomes = True
 DJANGO =
     1.11: dj111
     2.0: dj20
+    2.1: dj21
     master: djmaster
 VARIANT =
     normal: normal
@@ -34,6 +36,7 @@ deps =
     py27: mock
     dj111: Django<1.12
     dj20: Django<2.1
+    dj21: Django>=2.1b1,<2.2
     djmaster: https://github.com/django/django/archive/master.tar.gz
     yubikey: django-otp-yubikey
     coverage

--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -33,7 +33,7 @@ class AdminSiteOTPRequiredMixin(object):
         """
         redirect_to = request.POST.get(REDIRECT_FIELD_NAME, request.GET.get(REDIRECT_FIELD_NAME))
 
-        if not redirect_to or not is_safe_url(url=redirect_to, host=request.get_host()):
+        if not redirect_to or not is_safe_url(url=redirect_to, allowed_hosts=[request.get_host()]):
             redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
 
         return redirect_to_login(redirect_to)
@@ -54,7 +54,7 @@ def patch_admin():
         """
         redirect_to = request.POST.get(REDIRECT_FIELD_NAME, request.GET.get(REDIRECT_FIELD_NAME))
 
-        if not redirect_to or not is_safe_url(url=redirect_to, host=request.get_host()):
+        if not redirect_to or not is_safe_url(url=redirect_to, allowed_hosts=[request.get_host()]):
             redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
 
         return redirect_to_login(redirect_to)

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -109,7 +109,8 @@ class LoginView(IdempotentSessionWizardView):
             self.redirect_field_name,
             self.request.GET.get(self.redirect_field_name, '')
         )
-        if not is_safe_url(url=redirect_to, host=self.request.get_host()):
+
+        if not is_safe_url(url=redirect_to, allowed_hosts=[self.request.get_host()]):
             redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
 
         device = getattr(self.get_user(), 'otp_device', None)


### PR DESCRIPTION
## Description
Changes the way `is_safe_url` is invoked and replaces `logout` view with `LogoutView` in the test `urls.py`.

## Motivation and Context
The upcoming 2.1 release will remove two features that were deprecated since Django 1.11:
* The `host` parameter in `is_safe_url` helper
* The function-based `logout` view

This PR updates the code to use the current approach.

## How Has This Been Tested?
I have run `tox` on my local machine and also tested manually that the module works as expected on Django 2.0 and 2.1b1 (I don't have a 1.11-based project to test against).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
