### PR TITLE
Fixed issue with byte string

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@ import unittest
 from django.test import TestCase
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qsl, urlparse
-
 from django_otp.util import random_hex
+
 from two_factor.models import PhoneDevice, random_hex_str
 from two_factor.utils import (
     backup_phones, default_device, get_otpauth_url, totp_digits,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import unittest
 from django.test import TestCase
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qsl, urlparse
+from django_otp.util import random_hex
 
 from two_factor.models import PhoneDevice, random_hex_str
 from two_factor.utils import (
@@ -107,3 +108,10 @@ class UtilsTest(UserMixin, TestCase):
         # test that returned random_hex_str is string
         h = random_hex_str()
         self.assertIsInstance(h, str)
+        # hex string must be 40 characters long. If cannot be longer, because CharField max_length=40
+        self.assertEqual(len(h), 40)
+
+        # Added tests to verify that we can safely remove IF statement from random_hex_str function
+        hh = random_hex().decode('utf-8')
+        self.assertIsInstance(hh, str)
+        self.assertEqual(len(hh), 40)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from six import string_types
 
 import sys
 import unittest
@@ -7,8 +8,8 @@ import unittest
 from django.test import TestCase
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qsl, urlparse
-from django_otp.util import random_hex
 
+from django_otp.util import random_hex
 from two_factor.models import PhoneDevice, random_hex_str
 from two_factor.utils import (
     backup_phones, default_device, get_otpauth_url, totp_digits,
@@ -107,11 +108,11 @@ class UtilsTest(UserMixin, TestCase):
     def test_random_hex(self):
         # test that returned random_hex_str is string
         h = random_hex_str()
-        self.assertIsInstance(h, str)
+        self.assertIsInstance(h, string_types)
         # hex string must be 40 characters long. If cannot be longer, because CharField max_length=40
         self.assertEqual(len(h), 40)
 
         # Added tests to verify that we can safely remove IF statement from random_hex_str function
         hh = random_hex().decode('utf-8')
-        self.assertIsInstance(hh, str)
+        self.assertIsInstance(hh, string_types)
         self.assertEqual(len(hh), 40)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from six import string_types
 
 import sys
 import unittest
@@ -108,11 +107,11 @@ class UtilsTest(UserMixin, TestCase):
     def test_random_hex(self):
         # test that returned random_hex_str is string
         h = random_hex_str()
-        self.assertIsInstance(h, string_types)
+        self.assertIsInstance(h, six.string_types)
         # hex string must be 40 characters long. If cannot be longer, because CharField max_length=40
         self.assertEqual(len(h), 40)
 
         # Added tests to verify that we can safely remove IF statement from random_hex_str function
         hh = random_hex().decode('utf-8')
-        self.assertIsInstance(hh, string_types)
+        self.assertIsInstance(hh, six.string_types)
         self.assertEqual(len(hh), 40)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qsl, urlparse
 
-from two_factor.models import PhoneDevice
+from two_factor.models import PhoneDevice, random_hex_str
 from two_factor.utils import (
     backup_phones, default_device, get_otpauth_url, totp_digits,
 )
@@ -102,3 +102,8 @@ class UtilsTest(UserMixin, TestCase):
         for no_digits in (6, 8):
             with self.settings(TWO_FACTOR_TOTP_DIGITS=no_digits):
                 self.assertEqual(totp_digits(), no_digits)
+
+    def test_random_hex(self):
+        # test that returned random_hex_str is string
+        h = random_hex_str()
+        self.assertIsInstance(h, str)

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -54,11 +54,13 @@ def key_validator(*args, **kwargs):
     """Wraps hex_validator generator, to keep makemigrations happy."""
     return hex_validator()(*args, **kwargs)
 
+
 def random_hex_str():
     h = random_hex()
     if isinstance(h, bytes):
-    	return h.decode('utf-8')
+        return h.decode('utf-8')
     return h
+
 
 class PhoneDevice(Device):
     """

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -55,8 +55,10 @@ def key_validator(*args, **kwargs):
     return hex_validator()(*args, **kwargs)
 
 def random_hex_str():
-    return random_hex().decode('utf-8')
-
+    h = random_hex()
+    if isinstance(h, bytes):
+    	return h.decode('utf-8')
+    return h
 
 class PhoneDevice(Device):
     """

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -54,6 +54,9 @@ def key_validator(*args, **kwargs):
     """Wraps hex_validator generator, to keep makemigrations happy."""
     return hex_validator()(*args, **kwargs)
 
+def random_hex_str():
+    return random_hex().decode('utf-8')
+
 
 class PhoneDevice(Device):
     """
@@ -65,7 +68,7 @@ class PhoneDevice(Device):
     number = PhoneNumberField()
     key = models.CharField(max_length=40,
                            validators=[key_validator],
-                           default=random_hex,
+                           default=random_hex_str,
                            help_text="Hex-encoded secret key")
     method = models.CharField(max_length=4, choices=PHONE_METHODS,
                               verbose_name=_('method'))

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -56,10 +56,7 @@ def key_validator(*args, **kwargs):
 
 
 def random_hex_str():
-    h = random_hex()
-    if isinstance(h, bytes):
-        return h.decode('utf-8')
-    return h
+    return random_hex().decode('utf-8')
 
 
 class PhoneDevice(Device):


### PR DESCRIPTION
When creating new Phone device from administrator panel, input is filled with b'.....'. Converted default value from bytes to string.

This is non-breaking bugfix.
