### PR TITLE
Update django-phonenumber-field and let user decide which phonenumbers lib to use

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,19 @@ and its dependencies:
 
     $ pip install django-two-factor-auth
 
+This project uses ``django-phonenumber-field`` which requires either ``phonenumbers``
+or ``phonenumberslite`` to be installed. Either manually install a supported version
+using ``pip`` or install ``django-two-factor-auth`` with the extras specified as in
+the below examples:
+
+.. code-block:: console
+
+    $ pip install django-two-factor-auth[phonenumbers]
+
+    OR
+
+    $ pip install django-two-factor-auth[phonenumberslite]
+
 Setup
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,15 @@ setup(
         'Django>=1.11',
         'django_otp>=0.6.0,<0.99',
         'qrcode>=4.0.0,<6.99',
-        'django-phonenumber-field>=1.1.0,<1.99',
+        'django-phonenumber-field>=1.1.0,<2.99',
         'django-formtools',
     ],
     extras_require={
         'Call': ['twilio>=6.0'],
         'SMS': ['twilio>=6.0'],
         'YubiKey': ['django-otp-yubikey'],
+        'phonenumbers': ['phonenumbers>=7.0.9,<8.99',],
+        'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99',],
     },
     include_package_data=True,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,9 @@ deps =
     coverage
 
     django-formtools
-    django-phonenumber-field>=0.7.2,<0.99
+    django-phonenumber-field>=1.1.0,<2.99
     django_otp>=0.6.0,<0.99
-    phonenumbers>=7.0.9,<7.99
+    phonenumbers>=7.0.9,<8.99
     qrcode>=4.0.0,<6.99
     twilio>=6.0
 ignore_outcome =


### PR DESCRIPTION
This is based on the discussion and work on #272

I added `phonenumbers` and `phonenumberslite` as extras_require. I've also updated the install documentation to note the need to add one of the two libraries. I also bumped the phonenumbers version as it is on 8.x now.

I ran all of the tests for python 2.7 and 3.6 using `tox` and all passed. I am having issues figuring out how to get `tox` going for the other versions, so I haven't yet tested them. I also manually confirmed I could install using the extras syntax and get the correct extra, be it `phonenumbers` or `phonenumberslite`.
