### PR TITLE
Only import 'patch_admin' module if TWO_FACTOR_PATCH_ADMIN==True

### DIFF
--- a/two_factor/apps.py
+++ b/two_factor/apps.py
@@ -7,6 +7,6 @@ class TwoFactorConfig(AppConfig):
     verbose_name = "Django Two Factor Authentication"
 
     def ready(self):
-        from .admin import patch_admin
         if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
+            from .admin import patch_admin
             patch_admin()


### PR DESCRIPTION
Allow `two_factor` to be used if `admin` is not in `INSTALLED_APPS`.

Without this patch, you get `LookupError: No installed app with label 'admin'` if you import `two_factor`, whatever the value of `TWO_FACTOR_PATCH_ADMIN`. Should be fairly self explanatory!

I didn't add any tests since this kind of import error is hard to test.

Thanks!
