### PR TITLE
Fix tests to cope with new throttle feature of django_otp

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -15,7 +15,7 @@ I use with Django?`_.
 
 django-otp
 ----------
-This project is used for generating one-time passwords. Version 0.3.x and above
+This project is used for generating one-time passwords. Version 0.6.x and above
 are supported.
 
 django-formtools

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
         'Django>=1.11',
-        'django_otp>=0.3.4,<0.99',
+        'django_otp>=0.6.0,<0.99',
         'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<1.99',
         'django-formtools',

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
 
     django-formtools
     django-phonenumber-field>=0.7.2,<0.99
-    django_otp>=0.3.4,<0.99
+    django_otp>=0.6.0,<0.99
     phonenumbers>=7.0.9,<7.99
     qrcode>=4.0.0,<6.99
     twilio>=6.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
django_otp 0.6.0 contains a security fix that throttles invalid token submission. This broke one of our tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
