### PR TITLE
Fix error PhoneDevice in Django 2.2

### DIFF
--- a/tests/test_views_phone.py
+++ b/tests/test_views_phone.py
@@ -55,7 +55,13 @@ class PhoneSetupTest(UserMixin, TestCase):
         self.assertContains(response, 'We\'ve sent a token to your phone')
         device = response.context_data['wizard']['form'].device
         fake.return_value.make_call.assert_called_with(
-            device=device, token='%06d' % totp(device.bin_key))
+            device=mock.ANY, token='%06d' % totp(device.bin_key))
+
+        args, kwargs = fake.return_value.make_call.call_args
+        submitted_device = kwargs['device']
+        self.assertEqual(submitted_device.number, device.number)
+        self.assertEqual(submitted_device.key, device.key)
+        self.assertEqual(submitted_device.method, device.method)
 
         response = self._post({'phone_setup_view-current_step': 'validation',
                                'validation-token': '123456'})

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -80,16 +80,6 @@ class PhoneDevice(Device):
             self.method,
         )
 
-    def __eq__(self, other):
-        if not isinstance(other, PhoneDevice):
-            return False
-        return self.number == other.number \
-            and self.method == other.method \
-            and self.key == other.key
-
-    def __hash__(self):
-        return hash("{!r},{!r},{!r}".format(self.number, self.method, self.key))
-
     @property
     def bin_key(self):
         return unhexlify(self.key.encode())

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -87,6 +87,9 @@ class PhoneDevice(Device):
             and self.method == other.method \
             and self.key == other.key
 
+    def __hash__(self):
+        return hash("{!r},{!r},{!r}".format(self.number, self.method, self.key))
+
     @property
     def bin_key(self):
         return unhexlify(self.key.encode())


### PR DESCRIPTION
## Description

Adding a `__hash__` function to the `PhoneDevice` model object, to allow it to be used in hash-based searches like `obj in set_of_objects`.

## Motivation and Context
Removing a phone device (e.g. deactivating 2-factor from an account that has a phone device attached) causes a 500 error right now in django 2.2 because django tries to see if the model object is in a set. Since the PhoneDevice model object overrides `__eq__`, it needs a `__hash__` function to allow it to be searched in a set. This resolves #298.

For the actual Hash value I used a hash of a format string made from the repr's of the number, key, and method fields.

## How Has This Been Tested?
All tests pass. Also I installed this on a failing 2.2 Django installation and confirmed that the error with removing a Phone device is resolved.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
