### PR TITLE
Add migration for byte string fix

### DIFF
--- a/two_factor/migrations/0006_phonedevice_key_default.py
+++ b/two_factor/migrations/0006_phonedevice_key_default.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+import two_factor.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('two_factor', '0005_auto_20160224_0450'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='phonedevice',
+            name='key',
+            field=models.CharField(default=two_factor.models.random_hex_str, help_text='Hex-encoded secret key', max_length=40, validators=[two_factor.models.key_validator]),
+        ),
+    ]


### PR DESCRIPTION
## Description

Changing the `PhoneDevice.key` default requires a model state migration.

See: 268c0d6 (Merge pull request #281 from Ameriks/byte_string_fix)

## Motivation and Context

Resolves "Your models have changes that are not yet reflected in a migration, and so won't be applied." warning message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Applied migration locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
