### PR TITLE
update django-phonenumber-field dependency version and allow picking between phonenumbers and phonenumberslite

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,19 @@ and its dependencies:
 
     $ pip install django-two-factor-auth
 
+This project uses ``django-phonenumber-field`` which requires either ``phonenumbers``
+or ``phonenumberslite`` to be installed. Either manually install a supported version
+using ``pip`` or install ``django-two-factor-auth`` with the extras specified as in
+the below examples:
+
+.. code-block:: console
+
+    $ pip install django-two-factor-auth[phonenumbers]
+
+    OR
+
+    $ pip install django-two-factor-auth[phonenumberslite]
+
 Setup
 -----
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,6 +21,11 @@ the below examples:
 
     $ pip install django-two-factor-auth[phonenumberslite]
 
+.. note::
+   django-phonenumber-field v3.0 and above does not support python 2.7 and 3.4,
+   you'll have to install 'django-phonenumber-field<3.0' manually if you're using
+   any of those versions of python.
+
 Setup
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,15 @@ setup(
         'Django>=1.11',
         'django_otp>=0.6.0,<0.99',
         'qrcode>=4.0.0,<6.99',
-        'django-phonenumber-field>=1.1.0,<1.99',
+        'django-phonenumber-field>=1.1.0,<3.99',
         'django-formtools',
     ],
     extras_require={
         'Call': ['twilio>=6.0'],
         'SMS': ['twilio>=6.0'],
         'YubiKey': ['django-otp-yubikey'],
+        'phonenumbers': ['phonenumbers>=7.0.9,<8.99',],
+        'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99',],
     },
     include_package_data=True,
     classifiers=[

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,18 +22,18 @@ class UtilsTest(UserMixin, TestCase):
         user = self.create_user()
         self.assertEqual(default_device(user), None)
 
-        user.phonedevice_set.create(name='backup', number='+1')
+        user.phonedevice_set.create(name='backup', number='+12024561111')
         self.assertEqual(default_device(user), None)
 
-        default = user.phonedevice_set.create(name='default', number='+1')
+        default = user.phonedevice_set.create(name='default', number='+12024561111')
         self.assertEqual(default_device(user).pk, default.pk)
 
     def test_backup_phones(self):
         self.assertQuerysetEqual(list(backup_phones(None)),
                                  list(PhoneDevice.objects.none()))
         user = self.create_user()
-        user.phonedevice_set.create(name='default', number='+1')
-        backup = user.phonedevice_set.create(name='backup', number='+1')
+        user.phonedevice_set.create(name='default', number='+12024561111')
+        backup = user.phonedevice_set.create(name='backup', number='+12024561111')
         phones = backup_phones(user)
 
         self.assertEqual(len(phones), 1)

--- a/tests/test_views_phone.py
+++ b/tests/test_views_phone.py
@@ -143,8 +143,8 @@ class PhoneDeleteTest(UserMixin, TestCase):
     def setUp(self):
         super(PhoneDeleteTest, self).setUp()
         self.user = self.create_user()
-        self.backup = self.user.phonedevice_set.create(name='backup', method='sms', number='+1')
-        self.default = self.user.phonedevice_set.create(name='default', method='call', number='+1')
+        self.backup = self.user.phonedevice_set.create(name='backup', method='sms', number='+12024561111')
+        self.default = self.user.phonedevice_set.create(name='default', method='call', number='+12024561111')
         self.login_user()
 
     def test_delete(self):

--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,9 @@ deps =
     coverage
 
     django-formtools
-    django-phonenumber-field>=0.7.2,<0.99
     django_otp>=0.6.0,<0.99
-    phonenumbers>=7.0.9,<7.99
+    django-phonenumber-field>=1.1.0,<2.99
+    phonenumbers>=7.0.9,<8.99
     qrcode>=4.0.0,<6.99
     twilio>=6.0
 ignore_outcome =


### PR DESCRIPTION
Same as #294 but with the tests fixed and max version of django-phonenumber-field set to 3.99