### PR TITLE
Pin django-formtools for python 2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'django_otp>=0.3.4,<0.99',
         'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<1.99',
-        'django-formtools',
+        'django-formtools<=2.0',
     ],
     extras_require={
         'Call': ['twilio>=6.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
     yubikey: django-otp-yubikey
     coverage
 
-    django-formtools
+    django-formtools<=2.0
     django-phonenumber-field>=0.7.2,<0.99
     django_otp>=0.3.4,<0.99
     phonenumbers>=7.0.9,<7.99


### PR DESCRIPTION
Pin django-formtools for python 2.7 support.

## Description
When trying to use django-two-factor-auth version 1.8.0 we realized that django-formtools was not pinned. This caused the code to break because the latest version of django-formtools was not compatible with version 1.8.0. In django-formtools >2.0 the super() call is expecting a class argument; however django-two-factor-auth version 1.8.0 is not passing the argument. I don't know how to update the docs on a minor version.

For reference:
https://github.com/jazzband/django-formtools/blob/2.0/formtools/wizard/views.py#L122
https://github.com/jazzband/django-formtools/blob/2.2/formtools/wizard/views.py#L122

It was producing this error:
```
backend_1_5b82166a2320 |   File "/usr/local/lib/python2.7/site-packages/two_factor/urls.py", line 11, in <module>
backend_1_5b82166a2320 |     view=LoginView.as_view(),
backend_1_5b82166a2320 |   File "/usr/local/lib/python2.7/site-packages/formtools/wizard/views.py", line 122, in as_view
backend_1_5b82166a2320 |     return super().as_view(**initkwargs)
backend_1_5b82166a2320 | TypeError: super() takes at least 1 argument (0 given)
```

## Motivation and Context
We're using Python 2.7 and thus we need to use django-two-factor-auth version 1.8.0. We're in the process of upgrading to python 3.7 but we need this temporary fix while we upgrade.

## How Has This Been Tested?
After making this change, reinstalled dependencies, and started docker the error went away.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**NOTE:** once this PR is approved, tag 1.8.1 should be created off of this branch in lieu of merging.