### PR TITLE
Make codecov informational only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,8 @@ coverage:
       default: false
       tests:
         paths: tests
+        informational: true
       two_factor:
         paths: two_factor
+        informational: true
+    patch: off


### PR DESCRIPTION
## Description

Update Codecov configuration so that it stops blocking PR merges

## Motivation and Context

Codecov is unable to tell the difference between "the developer removed
lines that had coverage" and "the developer added lines without
coverage". Often maintenance work is the former rather than the latter,
but pull requests still end up being marked as "failed".

Codecov should still submit coverage reports as comments to pull
requests.

## How Has This Been Tested?

No.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
