### PR TITLE
Convert extras names to lowercase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
         'django-formtools',
     ],
     extras_require={
-        'Call': ['twilio>=6.0'],
-        'SMS': ['twilio>=6.0'],
-        'YubiKey': ['django-otp-yubikey'],
+        'call': ['twilio>=6.0'],
+        'sms': ['twilio>=6.0'],
+        'yubikey': ['django-otp-yubikey'],
         'phonenumbers': ['phonenumbers>=7.0.9,<8.99',],
         'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99',],
     },


### PR DESCRIPTION
## Description

Converts the extra names in the package's `extras_require` to lowercase, working around pypa/pip#4617.

## Motivation and Context

For example, even with the latest pip, `pip install django-setup-tools[SMS]` will not install `twilio`, even though it should.

## How Has This Been Tested?

Tested by installing `.[sms]`, and by confirming that installing `.[SMS]` continues to do what it did before.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~ (Only `phonenumbers` and `phonenumberslite` seem to be mentioned, which are already lowercase.)
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have added tests to cover my changes.~~
- [X] All new and existing tests passed.
