### PR TITLE
Avoid a django_otp version > 0.7.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
         'Django>=1.11',
-        'django_otp>=0.6.0,<0.99',
+        'django_otp>=0.6.0,<=0.7.5',
         'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<3.99',
         'django-formtools',


### PR DESCRIPTION
related to the use of random_hex_str (https://github.com/Bouke/django-two-factor-auth/blob/master/two_factor/models.py#L57)

## Description

Fix the needed version of django_otp to <= 0.7.5 (to avoid changes made in >=0.8)
