### PR TITLE
Unifying LoginView API with Django Project (adding support for success_url_allowed_hosts and redirect_authenticated_user) (Revised)

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -78,6 +78,18 @@ class LoginTest(UserMixin, TestCase):
              'login_view-current_step': 'auth'})
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
+    def test_valid_login_with_redirect_authenticated_user(self):
+        user = self.create_user()
+        response = self.client.get(
+            reverse('custom-redirect-authenticated-user-login')
+        )
+        self.assertEqual(response.status_code, 200)
+        self.client.force_login(user)
+        response = self.client.get(
+            reverse('custom-redirect-authenticated-user-login')
+        )
+        self.assertRedirects(response, reverse('two_factor:profile'))
+
     @mock.patch('two_factor.views.core.signals.user_verified.send')
     def test_with_generator(self, mock_signal):
         user = self.create_user()

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -90,6 +90,15 @@ class LoginTest(UserMixin, TestCase):
         )
         self.assertRedirects(response, reverse('two_factor:profile'))
 
+    def test_valid_login_with_redirect_authenticated_user_loop(self):
+        redirect_url = reverse('custom-redirect-authenticated-user-login')
+        user = self.create_user()
+        self.client.force_login(user)
+        with self.assertRaises(ValueError):
+            self.client.get(
+                '%s?%s' % (reverse('custom-redirect-authenticated-user-login'), 'next=' + redirect_url),
+            )
+
     @mock.patch('two_factor.views.core.signals.user_verified.send')
     def test_with_generator(self, mock_signal):
         user = self.create_user()

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -62,11 +62,21 @@ class LoginTest(UserMixin, TestCase):
         redirect_url = reverse('two_factor:setup')
         self.create_user()
         response = self.client.post(
-            '%s?%s' % (reverse('custom-login'), 'next_page=' + redirect_url),
+            '%s?%s' % (reverse('custom-field-name-login'), 'next_page=' + redirect_url),
             {'auth-username': 'bouke@example.com',
              'auth-password': 'secret',
              'login_view-current_step': 'auth'})
         self.assertRedirects(response, redirect_url)
+
+    def test_valid_login_with_allowed_external_redirect(self):
+        redirect_url = 'https://test.allowed-success-url.com'
+        self.create_user()
+        response = self.client.post(
+            '%s?%s' % (reverse('custom-allowed-success-url-login'), 'next=' + redirect_url),
+            {'auth-username': 'bouke@example.com',
+             'auth-password': 'secret',
+             'login_view-current_step': 'auth'})
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     @mock.patch('two_factor.views.core.signals.user_verified.send')
     def test_with_generator(self, mock_signal):

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -78,6 +78,17 @@ class LoginTest(UserMixin, TestCase):
              'login_view-current_step': 'auth'})
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
+    def test_valid_login_with_disallowed_external_redirect(self):
+        redirect_url = 'https://test.disallowed-success-url.com'
+        self.create_user()
+        response = self.client.post(
+            '%s?%s' % (reverse('custom-allowed-success-url-login'), 'next=' + redirect_url),
+            {'auth-username': 'bouke@example.com',
+             'auth-password': 'secret',
+             'login_view-current_step': 'auth'})
+        self.assertRedirects(response, reverse('two_factor:profile'), fetch_redirect_response=False)
+
+
     def test_valid_login_with_redirect_authenticated_user(self):
         user = self.create_user()
         response = self.client.get(

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -14,9 +14,16 @@ urlpatterns = [
         name='logout',
     ),
     url(
-        regex=r'^account/custom-login/$',
+        regex=r'^account/custom-field-name-login/$',
         view=LoginView.as_view(redirect_field_name='next_page'),
-        name='custom-login',
+        name='custom-field-name-login',
+    ),
+    url(
+        regex=r'^account/custom-allowed-success-url-login/$',
+        view=LoginView.as_view(
+            success_url_allowed_hosts={'test.allowed-success-url.com'}
+        ),
+        name='custom-allowed-success-url-login',
     ),
 
     url(

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -25,6 +25,13 @@ urlpatterns = [
         ),
         name='custom-allowed-success-url-login',
     ),
+    url(
+        regex=r'^account/custom-redirect-authenticated-user-login/$',
+        view=LoginView.as_view(
+            redirect_authenticated_user=True
+        ),
+        name='custom-redirect-authenticated-user-login',
+    ),
 
     url(
         regex=r'^secure/$',

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -17,7 +17,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, resolve_url
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url, url_has_allowed_host_and_scheme
+from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
@@ -126,7 +126,7 @@ class LoginView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
             self.redirect_field_name,
             self.request.GET.get(self.redirect_field_name, '')
         )
-        url_is_safe = url_has_allowed_host_and_scheme(
+        url_is_safe = is_safe_url(
             url=redirect_to,
             allowed_hosts=self.get_success_url_allowed_hosts(),
             require_https=self.request.is_secure(),

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -116,10 +116,14 @@ class LoginView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
                                        user=self.get_user(), device=device)
         return redirect(redirect_to)
 
+    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
     def get_success_url(self):
         url = self.get_redirect_url()
         return url or resolve_url(settings.LOGIN_REDIRECT_URL)
 
+    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L67
     def get_redirect_url(self):
         """Return the user-originating redirect URL if it's safe."""
         redirect_to = self.request.POST.get(
@@ -214,6 +218,8 @@ class LoginView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
             context['cancel_url'] = resolve_url(settings.LOGOUT_URL)
         return context
 
+    # Copied from django.conrib.auth.views.LoginView  (Branch: stable/1.11.x)
+    # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L49
     @method_decorator(sensitive_post_parameters())
     @method_decorator(csrf_protect)
     @method_decorator(never_cache)


### PR DESCRIPTION
## Description

Adding `success_url_allowed_hosts` and `redirect_authenticated_user` like in  django.contrib.auth.views.LoginView to `two_factor.views.LoginView`.

## Motivation and Context

The [LoginView in the main Django Project](https://github.com/django/django/blob/4f61810751751b8c5070ce038ea57e949650e9e3/django/contrib/auth/views.py#L40) can be customized using some class variables that are [mentioned in the Django documentation](https://docs.djangoproject.com/en/3.0/topics/auth/default/#all-authentication-views).

`redirect_field_name` and `template_name` of these customizations are already work with `two_factor.views.LoginView`.

I added `success_url_allowed_hosts` and `redirect_authenticated_user`.

These features facilitate to move from the Django authentication system to django-two-factor-auth if developers already rely on some customizations, is a step to unify the public API of this repo and the Django authentication system and (obviously) enriches the functionality of django-two-factor-auth.

## How Has This Been Tested?

Full test coverage is already included.
Other areas of the code should not be affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## References

This reopens and carries on with (closed) pull request https://github.com/Bouke/django-two-factor-auth/pull/348 .
