### PR TITLE
Move login redirect URL logic into its own method

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -68,6 +68,26 @@ class LoginTest(UserMixin, TestCase):
              'login_view-current_step': 'auth'})
         self.assertRedirects(response, redirect_url)
 
+    def test_valid_login_with_unsafe_redirect(self):
+        redirect_url = "//example.com"
+        self.create_user()
+        response = self._post({'auth-username': 'bouke@example.com',
+                               'auth-password': 'secret',
+                               'login_view-current_step': 'auth',
+                               'next': redirect_url})
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL), fetch_redirect_response=False)
+
+    @mock.patch('two_factor.views.core.LoginView.get_redirect_url')
+    def test_valid_login_with_overridden_redirect(self, mock_get_redirect_url):
+        redirect_url = "//example.com"
+        mock_get_redirect_url.return_value = redirect_url
+
+        self.create_user()
+        response = self._post({'auth-username': 'bouke@example.com',
+                               'auth-password': 'secret',
+                               'login_view-current_step': 'auth'})
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+
     @mock.patch('two_factor.views.core.signals.user_verified.send')
     def test_with_generator(self, mock_signal):
         user = self.create_user()


### PR DESCRIPTION
## Description

Move the determination of the redirect URL to its own method, when redirecting in LoginView.done. 

## Motivation and Context

This makes it possible for users to make their own class where `get_redirect_url` is overridden, so that business logic can determine the next URL. For example, [Zulip](https://github.com/zulip/zulip/blob/master/zerver/views/auth.py#L700-L708) has user-specific "realms", so they want to determine the redirect URL only after login.

This moves the redirect URL logic to `get_redirect_url`, and calls that just before calling `redirect`. This moves the URL logic after `signals.user_verified.send`, which means a change in behavior if the URL logic raises an exception. For example, if the given URL cannot be resolved. It used to not call `signals.user_verified.send`, but now it does. I think this is expected behavior; the user is logged in after all.

## How Has This Been Tested?

I added two unit tests to `LoginTest`. I have also tested it in a little example project.

The default `get_redirect_url` shouldn't be able to redirect to an unsafe (off-domain) URL. When overriding `get_redirect_url` it can do whatever it wants, including redirecting to an unsafe URL. This commit adds tests to reflect this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
