### PR TITLE
StaticDevice now supports throttling (fixes failing test in master)

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -198,6 +198,8 @@ class LoginTest(UserMixin, TestCase):
         self.assertEqual(response.context_data['wizard']['form'].errors,
                          {'__all__': ['Invalid token. Please make sure you '
                                       'have entered it correctly.']})
+        # static devices are throttled
+        device.throttle_reset()
 
         # Valid token should be accepted.
         response = self._post({'backup-otp_token': 'abcdef123',


### PR DESCRIPTION
django-otp>=0.9 throttles StaticDevices and tests need to be updated to
reflect that

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added `device.reset_throttle()` to one failing test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Tests were failing in master due to changes from django-otp

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As well as the updated test, I have run the app locally with django-otp 0.9.1 and was able to log in with a backup token.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
