### PR TITLE
Push builds to pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,19 @@
 [bumpversion]
 current_version = 1.11.0
-files = setup.py docs/conf.py
 commit = True
 tag = True
 tag_name = {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>.*))?
+serialize = 
+	{major}.{minor}.{patch}.{release}
+	{major}.{minor}.{patch}
+	{major}.{minor}.{release}
+	{major}.{minor}
 
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:docs/conf.py]
+search = release = '{current_version}'
+replace = release = '{new_version}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: publish
+
+on:
+  push:
+    branches: [master]
+    tags: ['*.*']
+
+jobs:
+  publish:
+
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine package version
+        id: vars
+        run: |
+          [[ ! $GITHUB_REF == refs/tags/* ]] && echo ::set-output name=version::$(git describe --tags | sed -r 's/-(.*?)-(.*?)$/.dev\1/g') || true
+          [[ $GITHUB_REF == refs/tags/* ]] && echo ::set-output name=version::${GITHUB_REF#refs/*/test-} || true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install build packages
+        run: pip install wheel bumpversion
+      - name: Bump version number
+        run: bumpversion patch --new-version ${{ steps.vars.outputs.version }} --no-tag --no-commit --verbose
+      - name: 🐍 Build package
+        run: python setup.py sdist bdist_wheel
+      - name: 📦 Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: 📦 Publish package to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ copyright = '2014, Bouke Haarsma'
 #
 
 # The full version, including alpha/beta/rc tags.
-release = '1.11.0'
+release = '1.11'
 
 # The short X.Y version.
 version = '.'.join(release.split('.')[0:2])

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,5 +32,5 @@ sphinx_rtd_theme
 # Build
 
 wheel
-bumpversion
+bump2version
 twine

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-two-factor-auth',
-    version='1.11.0',
+    version='1.11',
     description='Complete Two-Factor Authentication for Django',
     long_description=open('README.rst').read(),
     author='Bouke Haarsma',

--- a/tox.ini
+++ b/tox.ini
@@ -71,10 +71,10 @@ commands =
 
 [testenv:flake8]
 basepython = python3.6
-deps = flake8
+deps = flake8<=3.99
 commands = flake8 two_factor
 
 [testenv:isort]
 basepython = python3.6
-deps = isort
+deps = isort<=4.99
 commands = isort -rc -c --diff example tests two_factor


### PR DESCRIPTION
This workflow pushes builds from the master branch automatically to [TestPyPI](https://test.pypi.org/project/django-two-factor-auth/#history) and tagged commits to normal PyPI automatically. So the workflow would be something like this:

1. Pull translations (we will probably integrate Transifex to make this automatic)
2. Tag the commit with the version number (e.g. `1.11.1`) and push the tag. Alternatively create a release in GitHub, which will also create a tag.
3. Workflow is triggered: will create the build and push to pypi

I've been testing the workflow on TestPyPI, but not to real PyPI yet. There is a small, yet deliberate, change in version numbering. Bumpversion will now leave out the patch if zero. So 1.12 instead of 1.12.0. PEP440 says that those versions are the same number, so I expect no issues from this.
