### PR TITLE
Add autofocus, autocomplete one-time-code and inputmode numeric to token input fields

### DIFF
--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -58,6 +58,10 @@ class PhoneNumberForm(ModelForm):
 class DeviceValidationForm(forms.Form):
     token = forms.IntegerField(label=_("Token"), min_value=1, max_value=int('9' * totp_digits()))
 
+    token.widget.attrs.update({'autofocus': 'autofocus'})
+    token.widget.attrs.update({'inputmode': 'numeric'})
+    token.widget.attrs.update({'autocomplete': 'one-time-code'})
+
     error_messages = {
         'invalid_token': _('Entered token is not valid.'),
     }
@@ -87,6 +91,10 @@ class YubiKeyDeviceForm(DeviceValidationForm):
 
 class TOTPDeviceForm(forms.Form):
     token = forms.IntegerField(label=_("Token"), min_value=0, max_value=int('9' * totp_digits()))
+
+    token.widget.attrs.update({'autofocus': 'autofocus'})
+    token.widget.attrs.update({'inputmode': 'numeric'})
+    token.widget.attrs.update({'autocomplete': 'one-time-code'})
 
     error_messages = {
         'invalid_token': _('Entered token is not valid.'),
@@ -144,6 +152,8 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, Form):
                                    max_value=int('9' * totp_digits()))
 
     otp_token.widget.attrs.update({'autofocus': 'autofocus'})
+    otp_token.widget.attrs.update({'inputmode': 'numeric'})
+    otp_token.widget.attrs.update({'autocomplete': 'one-time-code'})
 
     # Our authentication form has an additional submit button to go to the
     # backup token form. When the `required` attribute is set on an input


### PR DESCRIPTION
## Description

By adding some extra attributes to the token input field the users gets a wider experience.

* Autofocus makes sure the users starts typing in the correct inout field. This was already added to the login token field but not when setting 2FA up for the first time.
* Autocomplete one-time-code is supported in Safari (maybe others as well?) and allow the browser to suggest codes send via SMS etc.
* Inputmode numeric makes surety best keyboard are selected on mobil.

## Motivation and Context

* https://www.twilio.com/blog/html-attributes-two-factor-authentication-autocomplete
* https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
