### PR TITLE
Removed upper limit of django-otp dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
         'Django>=2.2',
-        'django_otp>=0.6.0,<0.99',
+        'django_otp>=0.6.0',
         'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<3.99',
         'django-formtools',

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     coverage
 
     django-formtools
-    django_otp>=0.6.0,<0.99
+    django_otp>=0.6.0
     django-phonenumber-field>=1.1.0,<2.99
     phonenumbers>=7.0.9,<8.99
     qrcode>=4.0.0,<6.99


### PR DESCRIPTION
django-otp recently released a 1.0.0 version.