### PR TITLE
Hide submit button using class instead of left-margin, makes it usable with CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The templates are now based on Bootstrap 4.
 - `DisableView` now checks user has verified before disabling two-factor on
   their account
+- Inline CSS has been removed  to allow stricter Content Security Policies.
 
 ## 1.12 - 2020-07-08
 ### Added

--- a/two_factor/templates/two_factor/_wizard_forms.html
+++ b/two_factor/templates/two_factor/_wizard_forms.html
@@ -1,6 +1,4 @@
-<table>
+<table class="mb-3">
   {{ wizard.management_form }}
   {{ wizard.form }}
 </table>
-{# Add empty paragraph to add some space below the table #}
-<p></p>

--- a/two_factor/templates/two_factor/_wizard_forms.html
+++ b/two_factor/templates/two_factor/_wizard_forms.html
@@ -2,3 +2,5 @@
   {{ wizard.management_form }}
   {{ wizard.form }}
 </table>
+{# Add empty paragraph to add some space below the table #}
+<p></p>

--- a/two_factor/templates/two_factor/core/login.html
+++ b/two_factor/templates/two_factor/core/login.html
@@ -27,7 +27,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <input type="submit" value="" class="hidden" />
+    <input type="submit" value="" class="d-none" />
 
     {% if other_devices %}
       <p>{% trans "Or, alternatively, use one of your backup phones:" %}</p>

--- a/two_factor/templates/two_factor/core/login.html
+++ b/two_factor/templates/two_factor/core/login.html
@@ -27,7 +27,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <div style="margin-left: -9999px"><input type="submit" value=""/></div>
+    <input type="submit" value="" class="hidden" />
 
     {% if other_devices %}
       <p>{% trans "Or, alternatively, use one of your backup phones:" %}</p>

--- a/two_factor/templates/two_factor/core/phone_register.html
+++ b/two_factor/templates/two_factor/core/phone_register.html
@@ -17,7 +17,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <input type="submit" value="" class="hidden" />
+    <input type="submit" value="" class="d-none" />
 
     {% include "two_factor/_wizard_actions.html" %}
   </form>

--- a/two_factor/templates/two_factor/core/phone_register.html
+++ b/two_factor/templates/two_factor/core/phone_register.html
@@ -17,7 +17,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <div style="margin-left: -9999px"><input type="submit" value=""/></div>
+    <input type="submit" value="" class="hidden" />
 
     {% include "two_factor/_wizard_actions.html" %}
   </form>

--- a/two_factor/templates/two_factor/core/setup.html
+++ b/two_factor/templates/two_factor/core/setup.html
@@ -49,7 +49,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <input type="submit" value="" class="hidden" />
+    <input type="submit" value="" class="d-none" />
 
     {% include "two_factor/_wizard_actions.html" %}
   </form>

--- a/two_factor/templates/two_factor/core/setup.html
+++ b/two_factor/templates/two_factor/core/setup.html
@@ -49,7 +49,7 @@
     {% include "two_factor/_wizard_forms.html" %}
 
     {# hidden submit button to enable [enter] key #}
-    <div style="margin-left: -9999px"><input type="submit" value=""/></div>
+    <input type="submit" value="" class="hidden" />
 
     {% include "two_factor/_wizard_actions.html" %}
   </form>


### PR DESCRIPTION
Hide submit button using class instead of left-margin, makes it usable with CSP

## Description

Replace inline CSS styles with existing bootstrap CSS class to hide the submit button.

I'm still a bit unhappy with the empty paragraph as hack. Without it, the table and the submit button row has no space between them. I can think of two solutions:

* Upgrade to bootstrap4 (which has appropriate margin classes) and add them to the table.
* Add a static CSS file with a custom class that adds that same margin.

If any of the two seem better to you, please let me know, I'm happy to amend the PR.

## Motivation and Context

This makes the default templates usable with a restrictive [Content-Security Policy](https://en.wikipedia.org/wiki/Content_Security_Policy).

## How Has This Been Tested?

I could not find any unittests for the UI. If there are, please let me know.

I have manually tested the views, and also tried the enter button of course (that this submit button seems to facilitate).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
