### PR TITLE
Stop trying to build on Python 3.5 for Django 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ matrix:
   exclude:
     - python: 3.5
       env: DJANGO=master VARIANT=normal
+    - python: 3.5
+      env: DJANGO=3.0 VARIANT=normal
+    - python: 3.5
+      env: DJANGO=3.1 VARIANT=normal
 
   allow_failures:
     - env: DJANGO=master VARIANT=normal


### PR DESCRIPTION
Exclude Django 3.x builds on Python 3.5

## Description

It doesn't really change anything for us per se as tox just exits with `0`. It does clean up Travis output.

## Motivation and Context

We don't build anything for Django 3.x on Python 3.5 and it gets confusing when all builds fail except Django 3.x on Python 3.5 (because tox exits with `0` having done nothing). Also general project tidiness.

## How Has This Been Tested?

Tests have been submitted to Travis and the two excluded builds do not appear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
