### PR TITLE
Removed obsolete providing_args Signal argument.

### DIFF
--- a/two_factor/signals.py
+++ b/two_factor/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
-user_verified = Signal(providing_args=['request', 'user', 'device'])
+# Signal additional parameters are: request, user, and device.
+user_verified = Signal()


### PR DESCRIPTION
The purely documentational providing_args argument was deprecated
in Django 3.1.
