### PR TITLE
Removed wrapping of django-otp random_hex function.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
         'Django>=2.2',
-        'django_otp>=0.6.0',
+        'django_otp>=0.8.0',
         'qrcode>=4.0.0,<6.99',
         'django-phonenumber-field>=1.1.0,<3.99',
         'django-formtools',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,9 @@ from urllib.parse import parse_qsl, urlparse
 
 from django.contrib.auth.hashers import make_password
 from django.test import TestCase, override_settings
+from django_otp.util import random_hex
 
-from two_factor.models import PhoneDevice, random_hex_str
+from two_factor.models import PhoneDevice
 from two_factor.utils import (
     backup_phones, default_device, get_otpauth_url, totp_digits,
 )
@@ -95,8 +96,8 @@ class UtilsTest(UserMixin, TestCase):
                 self.assertEqual(totp_digits(), no_digits)
 
     def test_random_hex(self):
-        # test that returned random_hex_str is string
-        h = random_hex_str()
+        # test that returned random_hex is string
+        h = random_hex()
         self.assertIsInstance(h, str)
         # hex string must be 40 characters long. If cannot be longer, because CharField max_length=40
         self.assertEqual(len(h), 40)

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -9,8 +9,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.oath import totp
-
-from two_factor.models import random_hex_str
+from django_otp.util import random_hex
 
 from .utils import UserMixin
 
@@ -95,7 +94,7 @@ class LoginTest(UserMixin, TestCase):
         mock_time.time.return_value = 12345.12
         user = self.create_user()
         user.totpdevice_set.create(name='default',
-                                   key=random_hex_str())
+                                   key=random_hex())
 
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
@@ -113,7 +112,7 @@ class LoginTest(UserMixin, TestCase):
         mock_time.time.return_value = 12345.12
         user = self.create_user()
         user.totpdevice_set.create(name='default',
-                                   key=random_hex_str())
+                                   key=random_hex())
 
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
@@ -132,7 +131,7 @@ class LoginTest(UserMixin, TestCase):
         mock_time.time.return_value = 12345.12
         user = self.create_user()
         device = user.totpdevice_set.create(name='default',
-                                            key=random_hex_str())
+                                            key=random_hex())
 
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
@@ -165,7 +164,7 @@ class LoginTest(UserMixin, TestCase):
         mock_time.time.return_value = 12345.12
         user = self.create_user()
         device = user.totpdevice_set.create(name='default',
-                                            key=random_hex_str())
+                                            key=random_hex())
 
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
@@ -210,7 +209,7 @@ class LoginTest(UserMixin, TestCase):
     def test_with_generator(self, mock_signal):
         user = self.create_user()
         device = user.totpdevice_set.create(name='default',
-                                            key=random_hex_str())
+                                            key=random_hex())
 
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
@@ -240,7 +239,7 @@ class LoginTest(UserMixin, TestCase):
     def test_throttle_with_generator(self, mock_signal):
         user = self.create_user()
         device = user.totpdevice_set.create(name='default',
-                                            key=random_hex_str())
+                                            key=random_hex())
 
         self._post({'auth-username': 'bouke@example.com',
                     'auth-password': 'secret',
@@ -265,11 +264,11 @@ class LoginTest(UserMixin, TestCase):
         user = self.create_user()
         for no_digits in (6, 8):
             with self.settings(TWO_FACTOR_TOTP_DIGITS=no_digits):
-                user.totpdevice_set.create(name='default', key=random_hex_str(),
+                user.totpdevice_set.create(name='default', key=random_hex(),
                                            digits=no_digits)
                 device = user.phonedevice_set.create(name='backup', number='+31101234567',
                                                      method='sms',
-                                                     key=random_hex_str())
+                                                     key=random_hex())
 
                 # Backup phones should be listed on the login form
                 response = self._post({'auth-username': 'bouke@example.com',
@@ -322,7 +321,7 @@ class LoginTest(UserMixin, TestCase):
     @mock.patch('two_factor.views.core.signals.user_verified.send')
     def test_with_backup_token(self, mock_signal):
         user = self.create_user()
-        user.totpdevice_set.create(name='default', key=random_hex_str())
+        user.totpdevice_set.create(name='default', key=random_hex())
         device = user.staticdevice_set.create(name='backup')
         device.token_set.create(token='abcdef123')
 
@@ -475,7 +474,7 @@ class RememberLoginTest(UserMixin, TestCase):
         super().setUp()
         self.user = self.create_user()
         self.device = self.user.totpdevice_set.create(name='default',
-                                            key=random_hex_str())
+                                            key=random_hex())
 
     def _post(self, data=None):
         return self.client.post(reverse('two_factor:login'), data=data)

--- a/tests/test_views_phone.py
+++ b/tests/test_views_phone.py
@@ -6,8 +6,9 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
 from django_otp.oath import totp
+from django_otp.util import random_hex
 
-from two_factor.models import PhoneDevice, random_hex_str
+from two_factor.models import PhoneDevice
 from two_factor.utils import backup_phones
 from two_factor.validators import validate_international_phonenumber
 from two_factor.views.core import PhoneDeleteView, PhoneSetupView
@@ -176,7 +177,7 @@ class PhoneDeviceTest(UserMixin, TestCase):
     def test_verify(self):
         for no_digits in (6, 8):
             with self.settings(TWO_FACTOR_TOTP_DIGITS=no_digits):
-                device = PhoneDevice(key=random_hex_str())
+                device = PhoneDevice(key=random_hex())
                 self.assertFalse(device.verify_token(-1))
                 self.assertFalse(device.verify_token('foobar'))
                 self.assertTrue(device.verify_token(totp(device.bin_key, digits=no_digits)))
@@ -189,7 +190,7 @@ class PhoneDeviceTest(UserMixin, TestCase):
         """
         for no_digits in (6, 8):
             with self.settings(TWO_FACTOR_TOTP_DIGITS=no_digits):
-                device = PhoneDevice(key=random_hex_str())
+                device = PhoneDevice(key=random_hex())
                 self.assertTrue(device.verify_token(str(totp(device.bin_key, digits=no_digits))))
 
     def test_unicode(self):

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ deps =
     coverage
 
     django-formtools
-    django_otp>=0.6.0
+    django_otp>=0.8.0
     django-phonenumber-field>=1.1.0,<2.99
     phonenumbers>=7.0.9,<8.99
     qrcode>=4.0.0,<6.99

--- a/two_factor/migrations/0006_phonedevice_key_default.py
+++ b/two_factor/migrations/0006_phonedevice_key_default.py
@@ -1,3 +1,4 @@
+import django_otp.util
 from django.db import migrations, models
 
 import two_factor.models
@@ -13,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='phonedevice',
             name='key',
-            field=models.CharField(default=two_factor.models.random_hex_str, help_text='Hex-encoded secret key', max_length=40, validators=[two_factor.models.key_validator]),
+            field=models.CharField(default=django_otp.util.random_hex, help_text='Hex-encoded secret key', max_length=40, validators=[two_factor.models.key_validator]),
         ),
     ]

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -3,7 +3,6 @@ from binascii import unhexlify
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django_otp.models import Device
 from django_otp.oath import totp
@@ -54,11 +53,6 @@ def key_validator(*args, **kwargs):
     return hex_validator()(*args, **kwargs)
 
 
-def random_hex_str(length=20):
-    # Could be removed once we depend on django_otp > 0.7.5
-    return force_str(random_hex(length=length))
-
-
 class PhoneDevice(Device):
     """
     Model with phone number and token seed linked to a user.
@@ -69,7 +63,7 @@ class PhoneDevice(Device):
     number = PhoneNumberField()
     key = models.CharField(max_length=40,
                            validators=[key_validator],
-                           default=random_hex_str,
+                           default=random_hex,
                            help_text="Hex-encoded secret key")
     method = models.CharField(max_length=4, choices=PHONE_METHODS,
                               verbose_name=_('method'))

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -32,9 +32,10 @@ from django.views.generic.base import View
 from django_otp import devices_for_user
 from django_otp.decorators import otp_required
 from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
+from django_otp.util import random_hex
 
 from two_factor import signals
-from two_factor.models import get_available_methods, random_hex_str
+from two_factor.models import get_available_methods
 from two_factor.utils import totp_digits
 
 from ..forms import (
@@ -532,7 +533,7 @@ class SetupView(IdempotentSessionWizardView):
         self.storage.extra_data.setdefault('keys', {})
         if step in self.storage.extra_data['keys']:
             return self.storage.extra_data['keys'].get(step)
-        key = random_hex_str(20)
+        key = random_hex(20)
         self.storage.extra_data['keys'][step] = key
         return key
 
@@ -662,7 +663,7 @@ class PhoneSetupView(IdempotentSessionWizardView):
         The key is preserved between steps and stored as ascii in the session.
         """
         if self.key_name not in self.storage.extra_data:
-            key = random_hex_str(20)
+            key = random_hex(20)
             self.storage.extra_data[self.key_name] = key
         return self.storage.extra_data[self.key_name]
 


### PR DESCRIPTION
## Description
From django-otp 0.8.0 and up, random_hex is always a string.
We don't need to wrap it any longer.

## Motivation and Context
This removes an unneeded function call.

## How Has This Been Tested?
The test suite continues to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
