### PR TITLE
Unify the text of the "back to profile" links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `DisableView` now checks user has verified before disabling two-factor on
   their account
 - Inline CSS has been removed  to allow stricter Content Security Policies.
+- Change "Back to Profile" to "Back to Account Security"
 
 ## 1.12 - 2020-07-08
 ### Added

--- a/two_factor/templates/two_factor/core/setup_complete.html
+++ b/two_factor/templates/two_factor/core/setup_complete.html
@@ -9,14 +9,14 @@
 
   {% if not phone_methods %}
     <p><a href="{% url 'two_factor:profile' %}"
-        class="btn btn-block btn-secondary">{% trans "Back to Profile" %}</a></p>
+        class="btn btn-block btn-secondary">{% trans "Back to Account Security" %}</a></p>
   {% else %}
     <p>{% blocktrans trimmed %}However, it might happen that you don't have access to
-      your primary token device. To enable account recovery, add a phone 
+      your primary token device. To enable account recovery, add a phone
       number.{% endblocktrans %}</p>
 
     <a href="{% url 'two_factor:profile' %}"
-        class="float-right btn btn-link">{% trans "Back to Profile" %}</a>
+        class="float-right btn btn-link">{% trans "Back to Account Security" %}</a>
     <p><a href="{% url 'two_factor:phone_create' %}"
         class="btn btn-success">{% trans "Add Phone Number" %}</a></p>
   {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The target page of the "two_factor:profile" path is in fact Account Security 
and using "Back to Profile" is a bit misleading as users may
expect to be back to their own profile page. Therefore
use the same text as the backup_tokens template to be
more consistent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The two links bring back to the same "Account Security" page but the text 
mentioning "Profile" rather suggests that the user profile page will be shown 
which is not what will happen. 

Note that there is no need to for new translation as the text itself already exists.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Simply use the package as usual, it is just a text change.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Template text change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
