### PR TITLE
Update django-phonenumber-field dependency to newer version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'Django>=2.2',
         'django_otp>=0.8.0',
         'qrcode>=4.0.0,<6.99',
-        'django-phonenumber-field>=1.1.0,<3.99',
+        'django-phonenumber-field>=1.1.0,<6',
         'django-formtools',
     ],
     extras_require={


### PR DESCRIPTION
Untested attempt to allow newer django-phonenumber-field dependency for issue #387

## Description
As above
PS: I would like to know why you required <3.99 and not <4 -- is this best practice or for some other reason?

## Motivation and Context
Issue #387

## How Has This Been Tested?
It hasn't.
https://github.com/stefanfoulis/django-phonenumber-field/blob/master/CHANGELOG.rst reports no breaking changes so fingers crossed, eh?

## Screenshots (if appropriate):
N/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
  - Provide Django 3.1 support in dependency
  - Allow package use when people are already using django-phonenumber-field 4 or newer
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
