### PR TITLE
Show/buttons by authentication

### DIFF
--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,25 @@
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+
+class TestWizardActionsTemplate(SimpleTestCase):
+    def test_render_template_authenticated(self):
+        template_name = 'two_factor/_wizard_actions.html' 
+
+        # Render the template
+        rendered_template = self.render_template(template_name, {'user': {'is_authenticated': True}, 'cancel_url': '/cancel', 'wizard': {'steps': {'prev': 'previous_step'}}})
+
+        # Assert that the "Sign in" button is not present for authenticated users
+        self.assertNotIn('<button type="submit" name="login" class="btn btn-dark">Sign in</button>', rendered_template)
+
+    def test_render_template_not_authenticated(self):
+        template_name = 'two_factor/_wizard_actions.html'
+
+        # Render the template
+        rendered_template = self.render_template(template_name, {'user': {'is_authenticated': False}})
+
+        # Assert that the "Sign in" button is present for non-authenticated users
+        self.assertIn('Sign in', rendered_template)
+
+    def render_template(self, template_name, context):
+        # Render the template with the context
+        return render_to_string(template_name, context)

--- a/two_factor/templates/two_factor/_wizard_actions.html
+++ b/two_factor/templates/two_factor/_wizard_actions.html
@@ -1,14 +1,25 @@
 {% load i18n %}
 
-{% if cancel_url %}
-  <a href="{{ cancel_url }}"
-     class="float-right btn btn-link">{% trans "Cancel" %}</a>
+{% if user.is_authenticated %}
+  {% if cancel_url %}
+    <a href="{{ cancel_url }}" class="float-right btn btn-link">{% trans "Cancel" %}</a>
+  {% endif %}
+  {% if wizard.steps.prev %}
+    <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="btn btn-secondary">
+      {% trans "Back" %}
+    </button>
+  {% else %}
+    <button disabled type="button" class="btn btn-secondary">{% trans "Back" %}</button>
+  {% endif %}
+  <button type="submit" class="btn btn-primary">{% trans "Next" %}</button>
 {% endif %}
-{% if wizard.steps.prev %}
-  <button name="wizard_goto_step" type="submit"
-          value="{{ wizard.steps.prev }}"
-          class="btn btn-secondary">{% trans "Back" %}</button>
+
+{% if user.is_authenticated %}
+  {# User is authenticated, don't show the "Sign in" button #}
 {% else %}
-  <button disabled name="" type="button" class="btn">{% trans "Back" %}</button>
+  <div class="d-grid mt-3">
+    <button type="submit" name="login" class="btn btn-dark">
+      {% trans "Sign in" %}
+    </button>
+  </div>
 {% endif %}
-<button type="submit" class="btn btn-primary">{% trans "Next" %}</button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a new feature for wizard templates. It adds a new sign-in button to the wizard actions and includes authentication for users. The sign-in button will be displayed only when the user is not authenticated. Otherwise, it will display other buttons. This feature ensures that the sign-in button is hidden when the user is logged in, without interfering with the functionality of the templates

## Motivation and Context
This feature helps to remove the cancel, back, and previous buttons that are shown on the sign-in page when the user is not authenticated.

## How Has This Been Tested?
New tests have been created for this feature, and they pass successfully. The two test functions are named test_render_template_authenticated and test_render_template_not_authenticated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
