### PR TITLE
Update installation doc; phonenumber required.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ Add the following apps to the ``INSTALLED_APPS``:
         'django_otp.plugins.otp_email',  # <- for email capability.
         'otp_yubikey',  # <- for yubikey capability.
         'two_factor',
-        'two_factor.plugins.phonenumber',  # <- for phone number capability.
+        'two_factor.plugins.phonenumber',  # <- Required, even if phone is not used.
         'two_factor.plugins.email',  # <- for email capability.
         'two_factor.plugins.yubikey',  # <- for yubikey capability.
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hi all,

love the package. I stumbled across an issue that it's clear from looking through the issues; (https://github.com/jazzband/django-two-factor-auth/issues/469) that the phonenumberfield/configuration is required, can we update the documentation to reflect this? This cost me a number of hours trying to dig this issue out.


## Description
<!--- Describe your changes in detail -->
Simple one line change to reflect that the phonenumber package is required.

## Motivation and Context
It makes it clear that even if you do not use the phone number field, it is required.

## How Has This Been Tested?
N/a.

## Screenshots (if appropriate):
N/a.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
