### PR TITLE
Update qrcode to 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+- Allow qrcode 8.x.
+
 ## 1.17.0
 ### Fixed
 - Fixed the XML syntax of the Twilio token.xml file.

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ is optional, it improves account security control over
 ``django.contrib.sessions``.
 
 Compatible with supported Django and Python versions. At the moment of writing
-that includes 4.2, 5.0, and 5.1 on Python 3.8 to 3.12.
+that includes 4.2, 5.0, and 5.1 on Python 3.9 to 3.13.
 Documentation is available at `readthedocs.io`_.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">= 3.9"
 dependencies = [
     "Django>=4.2",
     "django_otp>=0.8.0",
-    "qrcode>=4.0.0,<7.99",
+    "qrcode<9",
     "django-phonenumber-field<9",
     "django-formtools",
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow updating to qrcode 8.x. Version was bumped to 8.x because of python support: 3.8 was dropped, 3.13 was added - same as this project :slightly_smiling_face: Their changelog: https://github.com/lincolnloop/python-qrcode/blob/main/CHANGES.rst#change-log

```
8.2 (01 May 2025)
-----------------

- Optimize QRColorMask apply_mask method for enhanced performance
- Fix typos on StyledPilImage embeded_* parameters.
  The old parameters with the typos are still accepted
  for backward compatibility.


8.1 (02 April 2025)
--------------------

- Added support for Python 3.13.

8.0 (27 September 2024)
------------------------

- Added support for Python 3.11 and 3.12.

- Drop support for Python <=3.8.

- Change local development setup to use Poetry_.

- Testsuite and code quality checks are done through Github Actions.

- Code quality and formatting utilises ruff_.

- Removed ``typing_extensions`` as a dependency, as it's no longer required
  with having Python 3.9+ as a requirement.
  having Python 3.9+ as a requirement.

- Only allow high error correction rate (`qrcode.ERROR_CORRECT_H`)
  when generating
  QR codes with embedded images to ensure content is readable

.. _Poetry: https://python-poetry.org
.. _ruff: https://astral.sh/ruff
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm using pip-sync/pip-compile which creates a requirements.txt from a pyproject.toml. With `django-two-factor-auth==1.17.0` in the pyproject.toml, `qrcode==7.4.2` also ends up in the requirements.txt. I also run dependabot for package updates and this fails when it wants to update it to a 8.x version. Because of the `qrcode>=4.0.0,<7.99` in  django-two-factor-auth's pyproject.toml:

```
Cannot install -r requirements.txt (line 154) and qrcode==8.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested qrcode==8.2
    django-two-factor-auth 1.17.0 depends on qrcode<7.99 and >=4.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

## How Has This Been Tested?
Locally in a fresh pyenv virtualenv for 3.13:
```
$ pip install -r requirements_dev.txt
$ make test
Ran 165 tests in 3.213s

OK (skipped=1)
Destroying test database for alias 'default'...
```

and with tox:

```
$ tox
  ...
  py312-dj51-normal: OK (16.33=setup[9.12]+cmd[6.88,0.34] seconds)
  py312-dj51-yubikey: OK (16.95=setup[9.16]+cmd[7.46,0.33] seconds)
  py312-dj51-custom_user: OK (16.28=setup[8.77]+cmd[7.10,0.41] seconds)
  py312-dj51-webauthn: FAIL code 1 (78.65=setup[10.81]+cmd[67.84] seconds)
  py312-dj52-normal: OK (15.45=setup[8.38]+cmd[6.75,0.32] seconds)
  py312-dj52-yubikey: OK (17.12=setup[9.18]+cmd[7.61,0.33] seconds)
  py312-dj52-custom_user: OK (16.37=setup[9.03]+cmd[7.01,0.34] seconds)
  py312-dj52-webauthn: FAIL code 1 (78.82=setup[10.90]+cmd[67.92] seconds)
  py313-dj51-normal: OK (15.34=setup[9.55]+cmd[5.36,0.42] seconds)
  py313-dj51-yubikey: OK (17.03=setup[10.51]+cmd[6.12,0.41] seconds)
  py313-dj51-custom_user: OK (16.10=setup[10.22]+cmd[5.43,0.44] seconds)
  py313-dj51-webauthn: FAIL code 1 (79.64=setup[13.12]+cmd[66.52] seconds)
  py313-dj52-normal: OK (15.81=setup[9.92]+cmd[5.48,0.41] seconds)
  py313-dj52-yubikey: OK (17.76=setup[10.58]+cmd[6.75,0.43] seconds)
  py313-dj52-custom_user: OK (16.30=setup[10.40]+cmd[5.47,0.43] seconds)
  py313-dj52-webauthn: FAIL code 1 (79.74=setup[12.81]+cmd[66.93] seconds)
  py312-djmain-normal: OK (22.81=setup[15.35]+cmd[7.10,0.35] seconds)
  py312-djmain-yubikey: OK (22.75=setup[14.66]+cmd[7.75,0.34] seconds)
  py312-djmain-custom_user: OK (21.85=setup[14.21]+cmd[7.29,0.35] seconds)
  py312-djmain-webauthn: IGNORED FAIL code 1 (85.12=setup[16.35]+cmd[68.77] seconds)
  py313-djmain-normal: OK (20.84=setup[15.04]+cmd[5.42,0.39] seconds)
  py313-djmain-yubikey: OK (22.48=setup[15.89]+cmd[6.19,0.40] seconds)
  py313-djmain-custom_user: OK (21.14=setup[15.18]+cmd[5.57,0.40] seconds)
  py313-djmain-webauthn: IGNORED FAIL code 1 (84.30=setup[17.73]+cmd[66.57] seconds)
  evaluation failed :( (1085.89 seconds)
```

The one failing test also fails for me on `jazzband/django-two-factor-auth`'s master branch. The output:
```
======================================================================
ERROR: test_webauthn_attestation_and_assertion (two_factor.plugins.webauthn.tests.test_e2e.E2ETests.test_webauthn_attestation_and_assertion)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/local/sandbox/django-two-factor-auth/two_factor/plugins/webauthn/tests/test_e2e.py", line 36, in setUp
    self.webdriver = webdriver.Chrome(options=options)
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/chrome/webdriver.py", line 45, in __init__
    super().__init__(
    ~~~~~~~~~~~~~~~~^
        browser_name=DesiredCapabilities.CHROME["browserName"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        keep_alive=keep_alive,
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/chromium/webdriver.py", line 66, in __init__
    super().__init__(command_executor=executor, options=options)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/remote/webdriver.py", line 250, in __init__
    self.start_session(capabilities)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/remote/webdriver.py", line 342, in start_session
    response = self.execute(Command.NEW_SESSION, caps)["value"]
               ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/remote/webdriver.py", line 429, in execute
    self.error_handler.check_response(response)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/local/sandbox/django-two-factor-auth/.tox/py313-djmain-webauthn/lib/python3.13/site-packages/selenium/webdriver/remote/errorhandler.py", line 232, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: DevToolsActivePort file doesn't exist
Stacktrace:
#0 0x5efcd115387a <unknown>
#1 0x5efcd0bf82e0 <unknown>
#2 0x5efcd0c3768d <unknown>
#3 0x5efcd0c31d41 <unknown>
#4 0x5efcd0c2dad7 <unknown>
#5 0x5efcd0c7de9e <unknown>
#6 0x5efcd0c7d466 <unknown>
#7 0x5efcd0c6f683 <unknown>
#8 0x5efcd0c3bb5b <unknown>
#9 0x5efcd0c3cf31 <unknown>
#10 0x5efcd11187cb <unknown>
#11 0x5efcd111c5d4 <unknown>
#12 0x5efcd10ff2c9 <unknown>
#13 0x5efcd111d178 <unknown>
#14 0x5efcd10e36bf <unknown>
#15 0x5efcd1140e78 <unknown>
#16 0x5efcd1141056 <unknown>
#17 0x5efcd1152b96 <unknown>
#18 0x7efefc09caa4 <unknown>
#19 0x7efefc129c3c <unknown>
````

I guess I am missing something to run the chrome tests :shrug: ? I tried downloading a chromedriver and geckodriver but couldn't get it to start properly..

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (at least: it remains status quo)
