### PR TITLE
fix #652: pick most-recently-used 2FA device when no device is named 'default'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## Unreleased
 ### Fixed
 - Compile translation files for Azerbaijani and Serbian, forgotten in 1.18.1.
+- `default_device()` now returns the user's most-recently-used non-backup
+  device when no device is named `"default"`, instead of returning `None`.
+  This fixes [#652](https://github.com/jazzband/django-two-factor-auth/issues/652):
+  users naming their first device anything other than `"default"` (e.g.
+  `"YubiKey"`, `"1Password"`) were never flagged as having 2FA enabled.
+  Backward-compatible: deployments that rely on a device named `"default"`
+  see no change.
+
+### Added
+- `TWO_FACTOR_DEFAULT_DEVICE_PICKER` setting: dotted path to a callable
+  that overrides the built-in primary-device selection policy. Lets
+  projects implement their own policies (e.g. "always prefer WebAuthn",
+  "alphabetical by name", "specific device class first") without
+  monkey-patching `default_device`. New public helper
+  `two_factor.utils.primary_device_candidates(devices)` is exported for
+  custom pickers that want to reuse the built-in backup-exclusion logic.
 
 ## 1.18.1
 ### Added

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,6 +62,38 @@ General Settings
   indefinitely in a state of having entered their password successfully but not
   having passed two factor authentication. Set to ``0`` to disable.
 
+``TWO_FACTOR_DEFAULT_DEVICE_PICKER`` (default: unset)
+  Dotted path to a callable used by :func:`~two_factor.utils.default_device`
+  to choose the user's primary 2FA device. The callable receives the unfiltered
+  list of confirmed devices returned by ``devices_for_user`` and must return
+  one of them or ``None``.
+
+  When unset, the built-in policy applies: a device named ``"default"`` wins
+  (back-compat with the upstream setup wizard's auto-naming), then the
+  most-recently-used non-backup device, then the non-backup device with the
+  lowest ``persistent_id``. Backup devices (``StaticDevice`` and any device
+  named ``"backup"``) are excluded by the built-in picker.
+
+  Set this to override the policy. Custom pickers may use the public helper
+  :func:`~two_factor.utils.primary_device_candidates` to apply the same
+  backup-exclusion logic, or pass it through unchanged for cases where backup
+  devices should also be eligible::
+
+      # myapp/settings.py
+      TWO_FACTOR_DEFAULT_DEVICE_PICKER = "myapp.utils.passkey_first_picker"
+
+      # myapp/utils.py
+      from two_factor.utils import primary_device_candidates
+
+      def passkey_first_picker(devices):
+          candidates = primary_device_candidates(devices)
+          # Prefer WebAuthn over TOTP regardless of recency.
+          webauthn = [d for d in candidates if d.__class__.__name__ == "WebauthnDevice"]
+          return webauthn[0] if webauthn else (candidates[0] if candidates else None)
+
+  The dotted path is resolved on each call (not cached at import time), so
+  the setting is overridable from tests via ``override_settings``.
+
 Phone-related settings
 ----------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
 import string
+from datetime import timedelta
 from unittest import mock
 from urllib.parse import parse_qsl, urlparse
 
 from django.contrib.auth.hashers import make_password
 from django.test import TestCase, override_settings
+from django.utils import timezone
+from django_otp.plugins.otp_static.models import StaticDevice
+from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp.util import random_hex
 from phonenumber_field.phonenumber import PhoneNumber
 
@@ -17,7 +21,7 @@ from two_factor.plugins.phonenumber.utils import (
 from two_factor.plugins.registry import GeneratorMethod, MethodRegistry
 from two_factor.utils import (
     USER_DEFAULT_DEVICE_ATTR_NAME, default_device, get_otpauth_url,
-    totp_digits,
+    primary_device_candidates, totp_digits,
 )
 from two_factor.views.utils import (
     get_remember_device_cookie, validate_remember_device_cookie,
@@ -42,6 +46,254 @@ class UtilsTest(UserMixin, TestCase):
         PhoneDevice.objects.all().delete()
         self.assertEqual(default_device(user).pk, default.pk)
         self.assertEqual(getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME).pk, default.pk)
+
+
+class DefaultDeviceSelectionTests(UserMixin, TestCase):
+    """Coverage for the multi-device selection rules in ``default_device``.
+
+    See PR fixing #652. Each test exercises one branch of the selection
+    policy and verifies the cache behaviour.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+
+    def _delete_cache(self):
+        # The function caches per-user-instance; reset between assertions
+        # that exercise different DB states on the same Python object.
+        if hasattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME):
+            delattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME)
+
+    def test_legacy_default_named_device_is_preferred(self):
+        # Backward-compat guarantee: a device literally named "default"
+        # always wins, even when there's a more recently used one.
+        # This protects every existing deployment that depends on the
+        # upstream wizard's "default" naming convention.
+        TOTPDevice.objects.create(
+            user=self.user, name='legacy-default-device',
+            last_used_at=timezone.now(),
+        )
+        explicit = TOTPDevice.objects.create(user=self.user, name='default')
+
+        self.assertEqual(default_device(self.user), explicit)
+
+    def test_most_recently_used_device_is_returned_when_no_default_named(self):
+        # Issue #652: users naming their devices ("YubiKey", "1Password")
+        # used to get None back. Now they get the most-recently-used.
+        old = TOTPDevice.objects.create(
+            user=self.user, name='Old YubiKey',
+            last_used_at=timezone.now() - timedelta(days=30),
+        )
+        recent = TOTPDevice.objects.create(
+            user=self.user, name='New YubiKey',
+            last_used_at=timezone.now(),
+        )
+
+        self.assertEqual(default_device(self.user), recent)
+        # And cached for the rest of the request.
+        self.assertEqual(
+            getattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME), recent
+        )
+        self.assertNotEqual(default_device(self.user), old)
+
+    def test_lowest_persistent_id_is_tiebreaker_when_no_last_used_at(self):
+        # Fresh enrollment, no logins yet: pick the device with the
+        # lowest persistent_id so behaviour is deterministic across
+        # requests (instead of dictionary-iteration-order dependent).
+        first = TOTPDevice.objects.create(user=self.user, name='Phone')
+        TOTPDevice.objects.create(user=self.user, name='Laptop')
+
+        chosen = default_device(self.user)
+        all_pids = sorted(
+            d.persistent_id for d in TOTPDevice.objects.filter(user=self.user)
+        )
+        self.assertEqual(chosen.persistent_id, all_pids[0])
+        self.assertEqual(chosen, first)
+
+    def test_static_backup_device_is_excluded(self):
+        # StaticDevice carries backup tokens and must never be picked
+        # as primary, even when it's the only device or the most
+        # recently used one. Picking it would mean re-prompting users
+        # for backup codes during a normal login.
+        StaticDevice.objects.create(
+            user=self.user, name='backup',
+            last_used_at=timezone.now(),
+        )
+
+        self.assertIsNone(default_device(self.user))
+
+        self._delete_cache()
+        # Add a real device with an OLDER last_used_at - it should
+        # still win against the more-recently-used StaticDevice.
+        totp = TOTPDevice.objects.create(
+            user=self.user, name='YubiKey',
+            last_used_at=timezone.now() - timedelta(days=10),
+        )
+        self.assertEqual(default_device(self.user), totp)
+
+    def test_devices_named_backup_are_excluded(self):
+        # `name == 'backup'` is the project-wide convention for backup
+        # devices (see ``backup_phones``). Honour it here too so a
+        # PhoneDevice the user enrolled as a backup phone is never
+        # silently promoted to primary.
+        self.user.phonedevice_set.create(
+            name='backup', number='+12024561111',
+        )
+        self.assertIsNone(default_device(self.user))
+
+    def test_no_device_returns_none_and_does_not_cache(self):
+        # Negative results must NOT be cached; otherwise enrolling a
+        # device later in the same request (e.g. during the setup
+        # wizard) would still return None until a fresh request.
+        self.assertIsNone(default_device(self.user))
+        self.assertFalse(hasattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME))
+
+        TOTPDevice.objects.create(user=self.user, name='default')
+        self.assertIsNotNone(default_device(self.user))
+
+    def test_anonymous_user_returns_none(self):
+        from django.contrib.auth.models import AnonymousUser
+        self.assertIsNone(default_device(AnonymousUser()))
+        self.assertIsNone(default_device(None))
+
+    def test_unconfirmed_devices_filtered_via_confirmed_kwarg(self):
+        # Backward-compat: callers that pass ``confirmed=False`` still
+        # only see unconfirmed devices, ``confirmed=None`` sees both.
+        # Required by the upstream setup wizard (mid-enrollment lookup).
+        TOTPDevice.objects.create(
+            user=self.user, name='confirmed-device', confirmed=True,
+        )
+        unconfirmed = TOTPDevice.objects.create(
+            user=self.user, name='in-progress', confirmed=False,
+        )
+
+        self._delete_cache()
+        self.assertEqual(
+            default_device(self.user, confirmed=False), unconfirmed
+        )
+
+
+# Module-level picker callables for the override-setting tests below.
+# Defined at module scope (not inside a class / method) so
+# ``import_string`` can resolve them via dotted path - that's the
+# whole contract of the ``TWO_FACTOR_DEFAULT_DEVICE_PICKER`` setting.
+
+def _picker_returns_first(devices):
+    return devices[0] if devices else None
+
+
+def _picker_returns_none(devices):
+    return None
+
+
+def _picker_picks_alphabetical_by_name(devices):
+    if not devices:
+        return None
+    return sorted(devices, key=lambda d: d.name)[0]
+
+
+class DefaultDevicePickerHookTests(UserMixin, TestCase):
+    """Coverage for the ``TWO_FACTOR_DEFAULT_DEVICE_PICKER`` extension point."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+
+    @override_settings(
+        TWO_FACTOR_DEFAULT_DEVICE_PICKER='tests.test_utils._picker_returns_first',
+    )
+    def test_custom_picker_is_invoked_when_setting_is_configured(self):
+        # The custom picker overrides the built-in policy entirely.
+        # Here it returns the first device unconditionally - even
+        # though the built-in would have skipped this StaticDevice as
+        # a backup. The hook puts the policy in the project's hands.
+        static = StaticDevice.objects.create(
+            user=self.user, name='backup',
+        )
+        self.assertEqual(default_device(self.user), static)
+
+    @override_settings(
+        TWO_FACTOR_DEFAULT_DEVICE_PICKER='tests.test_utils._picker_returns_none',
+    )
+    def test_custom_picker_returning_none_is_handled(self):
+        # A picker is allowed to deliberately return None even when
+        # devices exist (e.g. a security policy that requires explicit
+        # admin enablement). default_device must not cache the None.
+        TOTPDevice.objects.create(user=self.user, name='YubiKey')
+        self.assertIsNone(default_device(self.user))
+        # Per the no-cache-None invariant, a follow-up call after a
+        # picker change must re-evaluate.
+        if hasattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME):
+            delattr(self.user, USER_DEFAULT_DEVICE_ATTR_NAME)
+
+    @override_settings(
+        TWO_FACTOR_DEFAULT_DEVICE_PICKER='tests.test_utils._picker_picks_alphabetical_by_name',
+    )
+    def test_custom_picker_receives_full_device_list_including_backups(self):
+        # The picker contract is "you receive every device returned by
+        # devices_for_user; you decide". We do NOT pre-filter so that
+        # custom pickers can implement policies that consider backup
+        # devices too (e.g. an admin tool that wants the truly first
+        # device by name regardless of role).
+        StaticDevice.objects.create(user=self.user, name='aaa-static')
+        TOTPDevice.objects.create(user=self.user, name='zzz-totp')
+        self.assertEqual(default_device(self.user).name, 'aaa-static')
+
+    def test_default_picker_is_used_when_setting_is_unset(self):
+        # No override; built-in policy applies. Regression guard against
+        # the resolver short-circuiting in a way that bypasses the
+        # built-in picker when the setting is missing.
+        explicit = TOTPDevice.objects.create(user=self.user, name='default')
+        self.assertEqual(default_device(self.user), explicit)
+
+
+class PrimaryDeviceCandidatesTests(TestCase):
+    """Coverage for the public ``primary_device_candidates`` helper.
+
+    Pure function, no DB needed - we feed it mock objects that
+    exercise the two exclusion rules. Public so custom pickers can
+    apply the same backup-exclusion logic without re-implementing it.
+    """
+
+    def test_excludes_static_devices(self):
+        static = mock.Mock(spec=StaticDevice, name='primary-named-static')
+        # Mock attribute `name` collides with mock's own constructor
+        # `name` kwarg; set after construction so the device's own
+        # `.name` attribute (the one the helper inspects) is correct.
+        static.name = 'whatever'
+        totp = mock.Mock(name='regular-totp')
+        totp.name = 'YubiKey'
+
+        result = primary_device_candidates([static, totp])
+        self.assertEqual(result, [totp])
+
+    def test_excludes_devices_named_backup(self):
+        # The 'backup' name convention is documented and used by
+        # backup_phones(); the helper must respect it for any device
+        # type, not only StaticDevice.
+        backup_phone = mock.Mock(name='backup-phone')
+        backup_phone.name = 'backup'
+        totp = mock.Mock(name='regular-totp')
+        totp.name = 'YubiKey'
+
+        result = primary_device_candidates([backup_phone, totp])
+        self.assertEqual(result, [totp])
+
+    def test_keeps_order_of_input(self):
+        # Custom pickers may build their own tie-breaking on top.
+        # Document the order-preservation contract so they can rely
+        # on it.
+        a = mock.Mock()
+        a.name = 'a'
+        b = mock.Mock()
+        b.name = 'b'
+        c = mock.Mock()
+        c.name = 'c'
+        self.assertEqual(primary_device_candidates([a, b, c]), [a, b, c])
+
+    def test_empty_list_returns_empty_list(self):
+        self.assertEqual(primary_device_candidates([]), [])
 
     def test_get_otpauth_url(self):
         for num_digits in (6, 8):

--- a/two_factor/plugins/webauthn/tests/test_e2e.py
+++ b/two_factor/plugins/webauthn/tests/test_e2e.py
@@ -99,10 +99,16 @@ class E2ETests(UserMixin, StaticLiveServerTestCase):
             By.XPATH, "//p[contains(text(), 'Primary method: Authenticate using a WebAuthn-compatible device')]")
 
         # try registering the same authenticator and fail
-        # (have to modify the existing authenticator first, so it's no longer the default one)
+        # The setup wizard redirects away if the user already has a
+        # primary 2FA device. Rename to 'backup' so default_device()
+        # treats it as a backup-only device (excluded from primary
+        # selection per the upstream convention also used by
+        # backup_phones()) and lets the wizard render. The device's
+        # credential_id remains in the DB, so the browser's
+        # excludeCredentials check still refuses re-registration.
         authenticator = default_device(user)
         self.assertIsNotNone(authenticator)
-        authenticator.name = 'not default anymore'
+        authenticator.name = 'backup'
         authenticator.save()
 
         self.webdriver.get(urljoin(self.base_url, reverse("two_factor:setup")))

--- a/two_factor/utils.py
+++ b/two_factor/utils.py
@@ -1,20 +1,118 @@
 from urllib.parse import quote, urlencode
 
 from django.conf import settings
+from django.utils.module_loading import import_string
 from django_otp import devices_for_user
+from django_otp.plugins.otp_static.models import StaticDevice
 
 USER_DEFAULT_DEVICE_ATTR_NAME = "_default_device"
 
 
 def default_device(user, confirmed=True):
+    """Return the user's primary 2FA device, or ``None`` if they have none.
+
+    The selection policy lives in a separate callable resolved at
+    call-time (see :func:`_get_default_device_picker`). Projects can
+    override the built-in policy by setting
+    ``TWO_FACTOR_DEFAULT_DEVICE_PICKER`` to the dotted path of any
+    callable taking ``(devices: list) -> Device | None``. The setting
+    is resolved per call (not cached at import time), so projects can
+    swap pickers without restart-time gymnastics.
+
+    Built-in policy (when the setting is unset, see
+    :func:`_pick_default_device` for the implementation):
+
+    1. A device explicitly named ``"default"``. This preserves
+       behaviour for existing deployments: the upstream setup wizard
+       names the first enrolled device ``"default"``, and many projects
+       have years of users with a primary device under that name. Such
+       deployments see no behaviour change.
+    2. The most-recently-used non-backup device (``last_used_at``
+       descending). For users with multiple named devices, this is
+       what they intuitively expect: the one they used last time
+       becomes the primary at next login - useful for users who
+       rotate between e.g. a YubiKey and a TOTP app.
+    3. The non-backup device with the lowest ``persistent_id`` as a
+       deterministic tie-breaker, used when the user has devices but
+       has not yet logged in with any of them (fresh enrollment).
+
+    Backup devices are excluded by the built-in picker:
+    ``StaticDevice`` (one-time backup tokens) and any device with
+    ``name == 'backup'`` (the convention also used by
+    :func:`~two_factor.plugins.phonenumber.utils.backup_phones`).
+    Custom pickers receive the unfiltered device list and may apply
+    whatever policy they need; ``primary_device_candidates`` is
+    exported as a public helper for the common case of "filter
+    backups out then decide".
+
+    The cache attribute on the user object (``USER_DEFAULT_DEVICE_ATTR_NAME``,
+    introduced in PR #466) is preserved. Negative results are not
+    cached, so a device enrolled later in the same request is found.
+    """
     if not user or user.is_anonymous:
-        return
+        return None
     if hasattr(user, USER_DEFAULT_DEVICE_ATTR_NAME):
         return getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME)
-    for device in devices_for_user(user, confirmed=confirmed):
+
+    devices = list(devices_for_user(user, confirmed=confirmed))
+    chosen = _get_default_device_picker()(devices)
+    if chosen is not None:
+        setattr(user, USER_DEFAULT_DEVICE_ATTR_NAME, chosen)
+    return chosen
+
+
+def _get_default_device_picker():
+    """Return the configured default-device picker callable.
+
+    Resolves ``TWO_FACTOR_DEFAULT_DEVICE_PICKER`` (a dotted path) at
+    call-time so settings overrides in tests and post-startup config
+    changes take effect immediately. Falls back to the built-in
+    :func:`_pick_default_device` when the setting is unset.
+    """
+    path = getattr(settings, 'TWO_FACTOR_DEFAULT_DEVICE_PICKER', None)
+    if path:
+        return import_string(path)
+    return _pick_default_device
+
+
+def primary_device_candidates(devices):
+    """Filter ``devices`` to those eligible to be the user's primary 2FA device.
+
+    Excludes ``StaticDevice`` (backup tokens) and any device named
+    ``"backup"`` (the convention used elsewhere in the codebase, see
+    :func:`~two_factor.plugins.phonenumber.utils.backup_phones`).
+
+    Public so custom :setting:`TWO_FACTOR_DEFAULT_DEVICE_PICKER`
+    callables can apply the same backup-exclusion logic without
+    re-implementing it.
+    """
+    return [
+        d for d in devices
+        if not isinstance(d, StaticDevice) and d.name != 'backup'
+    ]
+
+
+def _pick_default_device(devices):
+    """Built-in default-device selection policy.
+
+    See :func:`default_device` for the rules. Split out so it's
+    testable in isolation (no DB / user object needed) and so the
+    :setting:`TWO_FACTOR_DEFAULT_DEVICE_PICKER` hook can swap it.
+    """
+    candidates = primary_device_candidates(devices)
+
+    for device in candidates:
         if device.name == 'default':
-            setattr(user, USER_DEFAULT_DEVICE_ATTR_NAME, device)
             return device
+
+    used = [d for d in candidates if getattr(d, 'last_used_at', None) is not None]
+    if used:
+        return max(used, key=lambda d: d.last_used_at)
+
+    if candidates:
+        return min(candidates, key=lambda d: d.persistent_id)
+
+    return None
 
 
 def get_otpauth_url(accountname, secret, issuer=None, digits=None):


### PR DESCRIPTION
## Description
`default_device(user)` matched only `device.name == "default"`. Users naming their device anything else (e.g. `"YubiKey"`, `"1Password"`) were treated as having no 2FA at all.
New selection order: a device named `"default"` (back-compat), then the most-recently-used non-backup device, then the lowest `persistent_id` as tie-breaker. Backup devices (`StaticDevice` and any device named `"backup"`, the same convention as `backup_phones()`) are excluded.
Adds `TWO_FACTOR_DEFAULT_DEVICE_PICKER` setting — dotted path to a callable `(devices) -> Device | None` — for projects that want a different policy without monkey-patching. Public helper `primary_device_candidates(devices)` is exported so custom pickers can reuse the backup-exclusion logic.
If you'd rather keep the legacy default (only `name="default"`) and ship MRU as an opt-in built-in picker, happy to refactor.
## Motivation and Context
Fixes #652.
## How Has This Been Tested?
Tox (`py39-dj42-{normal,yubikey,custom_user,webauthn}`), unit tests added for every branch of the new policy and the picker hook.
`test_webauthn_attestation_and_assertion` was renaming the device to `'not default anymore'` to bypass the setup wizard's `if default_device(user): redirect` guard. With the new policy that workaround stops working, so the rename target is now `'backup'` (using the same exclusion convention exposed by `primary_device_candidates`). The credential ID stays in the DB, so the duplicate-detection path being tested still fires.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.