### PR TITLE
Allow adding more 2FA methods by re-entering the setup wizard

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
-from two_factor.forms import AuthenticationTokenForm
+from two_factor.forms import AuthenticationTokenForm, TOTPDeviceForm
+
+from .utils import UserMixin
 
 
 class FormTests(TestCase):
@@ -8,3 +10,18 @@ class FormTests(TestCase):
         form = AuthenticationTokenForm(None, None, data={'otp_token': '005428'})
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['otp_token'], '005428')
+
+
+class TOTPDeviceFormSaveTests(UserMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+
+    def _form(self):
+        return TOTPDeviceForm(key='1234567890abcdef', user=self.user)
+
+    def test_defaults_to_default_name(self):
+        self.assertEqual(self._form().save().name, 'default')
+
+    def test_saves_with_given_name(self):
+        self.assertEqual(self._form().save(name='sms').name, 'sms')

--- a/tests/test_views_setup.py
+++ b/tests/test_views_setup.py
@@ -2,11 +2,14 @@ from base64 import b32decode
 from binascii import unhexlify
 from unittest import mock
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.oath import totp
+
+from two_factor.plugins.registry import registry
+from two_factor.views import SetupView
 
 from .utils import UserMixin, method_registry
 
@@ -214,11 +217,12 @@ class SetupTest(UserMixin, TestCase):
         self.assertEqual(phones[0].number.as_e164, '+31101234567')
         self.assertEqual(phones[0].method, 'sms')
 
-    def test_already_setup(self):
+    def test_reentry_allowed_when_already_configured(self):
+        # A configured user can re-enter the wizard to add another method.
         self.enable_otp()
         self.login_user()
         response = self.client.get(reverse('two_factor:setup'))
-        self.assertRedirects(response, reverse('two_factor:setup_complete'))
+        self.assertEqual(response.status_code, 200)
 
     def test_no_double_login(self):
         """
@@ -253,3 +257,27 @@ class SetupTest(UserMixin, TestCase):
 
         # view should return HTTP 400 Bad Request
         self.assertEqual(response.status_code, 400)
+
+
+class SetupViewDeviceNameTest(UserMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.view = SetupView()
+        self.view.request = RequestFactory().get('/')
+        self.view.request.user = self.user
+
+    def test_first_device_is_named_default(self):
+        method = registry.get_method('generator')
+        self.assertEqual(self.view.get_new_device_name(method), 'default')
+
+    def test_additional_device_is_named_after_its_method(self):
+        self.user.totpdevice_set.create(name='default')
+        method = registry.get_method('email')
+        self.assertEqual(self.view.get_new_device_name(method), 'email')
+
+    def test_duplicate_method_is_named_after_its_method(self):
+        # A second device of an already-configured method is allowed.
+        self.user.totpdevice_set.create(name='default')
+        method = registry.get_method('generator')
+        self.assertEqual(self.view.get_new_device_name(method), 'generator')

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -93,12 +93,12 @@ class TOTPDeviceForm(forms.Form):
             raise forms.ValidationError(self.error_messages['invalid_token'])
         return token
 
-    def save(self):
+    def save(self, name='default'):
         return TOTPDevice.objects.create(user=self.user, key=self.key,
                                          tolerance=self.tolerance, t0=self.t0,
                                          step=self.step, drift=self.drift,
                                          digits=self.digits,
-                                         name='default')
+                                         name=name)
 
 
 class DisableForm(forms.Form):

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -476,14 +476,6 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         method_key = method_data.get('method', None)
         return registry.get_method(method_key)
 
-    def get(self, request, *args, **kwargs):
-        """
-        Start the setup wizard. Redirect if already enabled.
-        """
-        if default_device(self.request.user):
-            return redirect(self.get_success_url())
-        return super().get(request, *args, **kwargs)
-
     def get_form(self, step=None, **kwargs):
         # Until https://github.com/jazzband/django-formtools/pull/62 is merged
         if (step or self.steps.current) not in self.form_list:
@@ -514,6 +506,13 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
     def get_available_methods(self):
         return registry.get_methods()
 
+    def get_new_device_name(self, method):
+        """Name for the device: 'default' for the first, else the method code."""
+        has_default = any(
+            device.name == 'default' for device in devices_for_user(self.request.user)
+        )
+        return method.code if has_default else 'default'
+
     def render_next_step(self, form, **kwargs):
         """
         In the validation step, ask the device to generate a challenge.
@@ -539,14 +538,16 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
             pass
 
         method = self.get_method()
+        name = self.get_new_device_name(method)
         # TOTPDeviceForm
         if method.code == 'generator':
             form = [form for form in form_list if isinstance(form, TOTPDeviceForm)][0]
-            device = form.save()
+            device = form.save(name=name)
 
         # PhoneNumberForm / YubiKeyDeviceForm / EmailForm / WebauthnDeviceValidationForm
         elif method.code in ('call', 'sms', 'yubikey', 'email', 'webauthn'):
             device = self.get_device()
+            device.name = name
             device.save()
 
         else:


### PR DESCRIPTION
## Description
Removes the SetupView.get() override that redirected any user with a 'default' device straight to setup_complete, so the setup wizard can now be re-entered to register additional methods. Device naming is centralised so this stays compatible with the existing login gate:
- SetupView.get_new_device_name(method) names the first device 'default' and every subsequent device after its method code
- SetupView.done() applies that name to the device it saves

## Motivation and Context
Previously, once a user had any 'default' OTP device, visiting the setup wizard redirected them to OTP display page, so there was no way to add a second authentication method. This change is the foundation for multi-method 2FA (managing/adding methods, multiple passkeys, etc.), which builds  on top of this branch.
  
## How Has This Been Tested?
- `python -m django test tests two_factor --pythonpath=./ --settings=tests.settings`
- New unit tests:
    - tests/test_forms.py::TOTPDeviceFormSaveTests — save() defaults to 'default' and honours a given name.
    - tests/test_views_setup.py::SetupViewDeviceNameTest — first device named 'default', additional named by method code (incl. a duplicate-method case).
    - tests/test_views_setup.py::SetupTest.test_reentry_allowed_when_already_configured — a configured user now reaches the wizard instead of being redirected.
  - Manual: ran the bundled example app and re-entered the wizard with an existing TOTP device to confirm a second method can be added.
  
  ## Types of changes
  <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to change)
  
  ## Checklist:
  <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
  <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
